### PR TITLE
Fix Dockerfile to respect Fly-provided PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=build /app/dist ./dist
 ENV NODE_ENV=production
 EXPOSE 4173
 
-CMD ["serve", "-s", "dist", "-l", "0.0.0.0:4173"]
+CMD ["sh", "-c", "serve -s dist -l tcp://0.0.0.0:${PORT:-4173}"]


### PR DESCRIPTION
## Summary
- update the Dockerfile runtime command to bind using the PORT environment variable so Fly's health checks succeed

## Testing
- CI=1 npx vite build --logLevel info

------
https://chatgpt.com/codex/tasks/task_e_68cd79aa3bc083278b730008a2c45d65