### PR TITLE
Préparer le frontend pour les salons de chat dynamiques

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,9 @@ import LessonComponent from './features/learning/components/LessonComponent';
 import CapsuleDetail from './features/capsules/components/CapsuleDetail';
 import MoleculePage from './features/learning/pages/MoleculePage';
 import ToolboxHubPage from './features/toolbox/pages/ToolboxHubPage';
+import ChatLayout from './features/chat/components/ChatLayout';
+import GeneralChatPage from './features/chat/pages/GeneralChatPage';
+import DomainChatPage from './features/chat/pages/DomainChatPage';
 
 
 
@@ -167,6 +170,10 @@ export default function App() {
           <Route path="/premium" element={<SubscriptionPage />} />
           <Route path="/payment-success" element={<PaymentSuccessPage />} />
           <Route path="/toolbox" element={<ToolboxHubPage />} />
+          <Route path="/chat" element={<ChatLayout />}>
+            <Route index element={<GeneralChatPage />} />
+            <Route path="domain/:domainId" element={<DomainChatPage />} />
+          </Route>
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
       </Route>

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -33,6 +33,41 @@ export const API_WS_URL = (() => {
   }
 })();
 
+export const CHAT_WS_URL = (() => {
+  try {
+    const base = new URL(API_WS_URL);
+    const trimmedPath = base.pathname.replace(/\/+$/, '');
+    const hasChatSuffix = /\/chat$/.test(trimmedPath);
+    base.pathname = hasChatSuffix ? trimmedPath : `${trimmedPath}/chat`;
+    base.search = '';
+    base.hash = '';
+    return base.toString();
+  } catch (error) {
+    console.warn('Unable to derive Chat WebSocket URL from API_WS_URL. Falling back to localhost.', error);
+    return 'ws://localhost:8000/api/v2/ws/chat';
+  }
+})();
+
+export const buildChatSocketUrl = (room, params = {}) => {
+  try {
+    const url = new URL(CHAT_WS_URL);
+    if (room) {
+      url.searchParams.set('room', room);
+    }
+    Object.entries(params || {}).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      const stringValue = typeof value === 'string' ? value : String(value);
+      if (stringValue.length === 0) return;
+      url.searchParams.set(key, stringValue);
+    });
+    return url.toString();
+  } catch (error) {
+    console.warn('Unable to build chat WebSocket URL. Falling back to default.', error);
+    const safeRoom = encodeURIComponent(room || 'general');
+    return `${CHAT_WS_URL}?room=${safeRoom}`;
+  }
+};
+
 export const buildApiUrl = (path = '') => {
   if (!path) return API_V2_URL;
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;

--- a/src/features/capsules/components/CapsuleDetail.jsx
+++ b/src/features/capsules/components/CapsuleDetail.jsx
@@ -30,6 +30,7 @@ import TopicIcon from '@mui/icons-material/Topic';
 import SchoolIcon from '@mui/icons-material/School';
 import CapsuleProgressBar from './CapsuleProgressBar';
 import FeedbackButtons from '../../learning/components/FeedbackButtons';
+import CapsuleChatPanel from '../../chat/components/CapsuleChatPanel';
 
 const CapsuleDetail = () => {
   const { domain, area, capsuleId } = useParams();
@@ -241,154 +242,184 @@ const CapsuleDetail = () => {
         </Grid>
       </Grid>
 
-      <Paper sx={{ p: { xs: 2, md: 3 } }}>
-        <Typography variant="h5" fontWeight={600} gutterBottom>
-          Plan d'apprentissage
-        </Typography>
+      <Grid container spacing={{ xs: 2, md: 3 }}>
+        <Grid item xs={12} md={8}>
+          <Paper sx={{ p: { xs: 2, md: 3 }, height: '100%' }}>
+            <Typography variant="h5" fontWeight={600} gutterBottom>
+              Plan d'apprentissage
+            </Typography>
 
-        {granules.length === 0 && (
-          <Alert severity="info">
-            Aucun contenu n'est encore disponible. Revenez un peu plus tard pendant que la capsule se
-            génère.
-          </Alert>
-        )}
+            {granules.length === 0 && (
+              <Alert severity="info">
+                Aucun contenu n'est encore disponible. Revenez un peu plus tard pendant que la capsule se
+                génère.
+              </Alert>
+            )}
 
-        <List sx={{ mt: 2 }}>
-          {granules.map((granule) => {
-            const isGranuleExpanded = expandedGranules.has(granule.id);
-            return (
-              <Box key={granule.id} sx={{ mb: 2, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
-                <ListItem onClick={() => toggleGranule(granule.id)} button>
-                  <ListItemIcon><Chip label={`Chap. ${granule.order}`} color="primary" /></ListItemIcon>
-                  <ListItemText primary={granule.title} />
-                  <Chip
-                    label={`${Math.round((granule.xp_percent ?? 0) * 100)}% XP`}
-                    size="small"
-                    color="info"
-                    sx={{ mr: 1 }}
-                  />
-                  <Chip
-                    label={granule.progress_status === 'completed' ? 'Terminé' : granule.progress_status === 'in_progress' ? 'En cours' : 'À faire'}
-                    size="small"
-                    color={granule.progress_status === 'completed' ? 'success' : granule.progress_status === 'in_progress' ? 'warning' : 'default'}
-                    sx={{ mr: 1 }}
-                  />
-                  <IconButton edge="end">
-                    {isGranuleExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                  </IconButton>
-                </ListItem>
-                <Collapse in={isGranuleExpanded} timeout="auto" unmountOnExit>
-                  <List component="div" disablePadding>
-                    {granule.molecules?.map((molecule) => {
-                      const moleculeState = atomsByMolecule[molecule.id] || {};
-                      const generationStatus = moleculeState.generationStatus || molecule.generation_status;
-                      const progressStatus = moleculeState.progressStatus || molecule.progress_status;
-                      const hasContent = moleculeState.atoms && moleculeState.atoms.length > 0;
-                      const isMoleculeExpanded = expandedMolecules.has(molecule.id);
-                      const isLoading = moleculeState.loading;
-                      const isLocked = molecule.is_locked;
-                      const progressLabel = progressStatus === 'completed' ? 'Validé' : progressStatus === 'failed' ? 'À rejouer' : progressStatus === 'in_progress' ? 'En cours' : 'À faire';
-                      const progressColor = progressStatus === 'completed' ? 'success' : progressStatus === 'failed' ? 'error' : progressStatus === 'in_progress' ? 'warning' : 'default';
-                      const moleculeXpPercent = Math.round((molecule.xp_percent ?? 0) * 100);
-                      return (
-                        <Box key={molecule.id} sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
-                         <ListItem button onClick={() => toggleMolecule(molecule)} sx={{ pl: 6 }}>
-                            <ListItemIcon><TopicIcon color="action" /></ListItemIcon>
-                            <ListItemText
-                              primary={molecule.title}
-                              secondary={`Leçon ${molecule.order}`}
-                            />
-                            {isLoading && <CircularProgress size={20} sx={{ mr: 1 }} />}
-                            <Chip
-                              label={`${moleculeXpPercent}% XP`}
-                              size="small"
-                              color="info"
-                              sx={{ mr: 1 }}
-                            />
-                            <Chip
-                              label={progressLabel}
-                              size="small"
-                              color={progressColor}
-                              sx={{ mr: 1 }}
-                            />
-                            <IconButton edge="end" onClick={(e) => { e.stopPropagation(); toggleMolecule(molecule); }}>
-                              {isMoleculeExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                            </IconButton>
-                            <FeedbackButtons
-                              contentType="molecule"
-                              contentId={molecule.id}
-                              initialRating={molecule.user_feedback_rating}
-                              initialReason={molecule.user_feedback_reason}
-                              initialComment={molecule.user_feedback_comment}
-                              onSuccess={() => {
-                                queryClient.invalidateQueries({ queryKey: ['capsule', domain, area, capsuleId] });
-                              }}
-                            />
-                            <Button
-                              size="small"
-                              sx={{ ml: 1 }}
-                              variant="contained"
-                              disabled={isLocked || !hasContent || generationStatus === 'pending' || generationStatus === 'failed' || isLoading}
-                              onClick={(e) => { e.stopPropagation(); startSession(molecule); }}
-                            >
-                              {isLocked ? 'Verrouillé' : generationStatus === 'pending' ? 'En cours...' : 'Étudier'}
-                            </Button>
-                          </ListItem>
-                         <Collapse in={isMoleculeExpanded} timeout="auto" unmountOnExit>
-                           <Box sx={{ pl: 8, pr: 3, py: 2 }}>
-                              <CapsuleProgressBar
-                                current={molecule.xp_earned ?? 0}
-                                target={molecule.xp_total ?? 0}
-                                label="XP de cette leçon"
-                                dense
-                              />
-                              {moleculeState.error && <Alert severity="error" sx={{ mb: 2 }}>{moleculeState.error}</Alert>}
-                              {generationStatus === 'pending' && (
-                                <Alert severity="info" sx={{ mb: 2 }}>
-                                  Génération en cours. Tu peux quitter cette page : tu recevras une notification quand la leçon sera prête.
-                                </Alert>
-                              )}
-                              {generationStatus === 'failed' && (
-                                <Alert severity="error" sx={{ mb: 2 }}>
-                                  La génération de cette leçon a échoué. Réessaie plus tard.
-                                </Alert>
-                              )}
-                              {!isLoading && !moleculeState.error && generationStatus !== 'pending' && (!moleculeState.atoms || moleculeState.atoms.length === 0) && (
-                                <Alert severity="info">Les contenus de cette leçon sont encore en train d'être générés.</Alert>
-                              )}
-                              {moleculeState.atoms?.map((atom) => {
-                                const type = (atom.content_type || '').toLowerCase();
-                                return (
-                                  <ListItem key={atom.id} sx={{ pl: 0, alignItems: 'center' }}>
-                                    <ListItemIcon>
-                                      {type === 'lesson' ? <ArticleIcon color="primary" /> : <QuizIcon color="secondary" />}
-                                    </ListItemIcon>
-                                    <ListItemText primary={atom.title} secondary={type === 'lesson' ? 'Leçon' : 'Quiz'} />
-                                    <FeedbackButtons
-                                      contentType="atom"
-                                      contentId={atom.id}
-                                      initialRating={atom.user_feedback_rating}
-                                      initialReason={atom.user_feedback_reason}
-                                      initialComment={atom.user_feedback_comment}
-                                      onSuccess={() => {
-                                        queryClient.invalidateQueries({ queryKey: ['capsule', domain, area, capsuleId] });
-                                      }}
-                                    />
-                                  </ListItem>
-                                );
-                              })}
+            <List sx={{ mt: 2 }}>
+              {granules.map((granule) => {
+                const isGranuleExpanded = expandedGranules.has(granule.id);
+                return (
+                  <Box key={granule.id} sx={{ mb: 2, border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+                    <ListItem onClick={() => toggleGranule(granule.id)} button>
+                      <ListItemIcon><Chip label={`Chap. ${granule.order}`} color="primary" /></ListItemIcon>
+                      <ListItemText primary={granule.title} />
+                      <Chip
+                        label={`${Math.round((granule.xp_percent ?? 0) * 100)}% XP`}
+                        size="small"
+                        color="info"
+                        sx={{ mr: 1 }}
+                      />
+                      <Chip
+                        label={granule.progress_status === 'completed' ? 'Terminé' : granule.progress_status === 'in_progress' ? 'En cours' : 'À faire'}
+                        size="small"
+                        color={granule.progress_status === 'completed' ? 'success' : granule.progress_status === 'in_progress' ? 'warning' : 'default'}
+                        sx={{ mr: 1 }}
+                      />
+                      <IconButton edge="end">
+                        {isGranuleExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                      </IconButton>
+                    </ListItem>
+                    <Collapse in={isGranuleExpanded} timeout="auto" unmountOnExit>
+                      <List component="div" disablePadding>
+                        {granule.molecules?.map((molecule) => {
+                          const moleculeState = atomsByMolecule[molecule.id] || {};
+                          const generationStatus = moleculeState.generationStatus || molecule.generation_status;
+                          const progressStatus = moleculeState.progressStatus || molecule.progress_status;
+                          const hasContent = moleculeState.atoms && moleculeState.atoms.length > 0;
+                          const isMoleculeExpanded = expandedMolecules.has(molecule.id);
+                          const isLoading = moleculeState.loading;
+                          const isLocked = molecule.is_locked;
+                          const progressLabel =
+                            progressStatus === 'completed'
+                              ? 'Validé'
+                              : progressStatus === 'failed'
+                                ? 'À rejouer'
+                                : progressStatus === 'in_progress'
+                                  ? 'En cours'
+                                  : 'À faire';
+                          const progressColor =
+                            progressStatus === 'completed'
+                              ? 'success'
+                              : progressStatus === 'failed'
+                                ? 'error'
+                                : progressStatus === 'in_progress'
+                                  ? 'warning'
+                                  : 'default';
+                          const moleculeXpPercent = Math.round((molecule.xp_percent ?? 0) * 100);
+                          return (
+                            <Box key={molecule.id} sx={{ borderTop: '1px solid', borderColor: 'divider' }}>
+                              <ListItem button onClick={() => toggleMolecule(molecule)} sx={{ pl: 6 }}>
+                                <ListItemIcon><TopicIcon color="action" /></ListItemIcon>
+                                <ListItemText
+                                  primary={molecule.title}
+                                  secondary={`Leçon ${molecule.order}`}
+                                />
+                                {isLoading && <CircularProgress size={20} sx={{ mr: 1 }} />}
+                                <Chip
+                                  label={`${moleculeXpPercent}% XP`}
+                                  size="small"
+                                  color="info"
+                                  sx={{ mr: 1 }}
+                                />
+                                <Chip
+                                  label={progressLabel}
+                                  size="small"
+                                  color={progressColor}
+                                  sx={{ mr: 1 }}
+                                />
+                                <IconButton edge="end" onClick={(e) => { e.stopPropagation(); toggleMolecule(molecule); }}>
+                                  {isMoleculeExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                                </IconButton>
+                                <FeedbackButtons
+                                  contentType="molecule"
+                                  contentId={molecule.id}
+                                  initialRating={molecule.user_feedback_rating}
+                                  initialReason={molecule.user_feedback_reason}
+                                  initialComment={molecule.user_feedback_comment}
+                                  onSuccess={() => {
+                                    queryClient.invalidateQueries({ queryKey: ['capsule', domain, area, capsuleId] });
+                                  }}
+                                />
+                                <Button
+                                  size="small"
+                                  sx={{ ml: 1 }}
+                                  variant="contained"
+                                  disabled={
+                                    isLocked ||
+                                    !hasContent ||
+                                    generationStatus === 'pending' ||
+                                    generationStatus === 'failed' ||
+                                    isLoading
+                                  }
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    startSession(molecule);
+                                  }}
+                                >
+                                  {isLocked ? 'Verrouillé' : generationStatus === 'pending' ? 'En cours...' : 'Étudier'}
+                                </Button>
+                              </ListItem>
+                              <Collapse in={isMoleculeExpanded} timeout="auto" unmountOnExit>
+                                <Box sx={{ pl: 8, pr: 3, py: 2 }}>
+                                  <CapsuleProgressBar
+                                    current={molecule.xp_earned ?? 0}
+                                    target={molecule.xp_total ?? 0}
+                                    label="XP de cette leçon"
+                                    dense
+                                  />
+                                  {moleculeState.error && <Alert severity="error" sx={{ mb: 2 }}>{moleculeState.error}</Alert>}
+                                  {generationStatus === 'pending' && (
+                                    <Alert severity="info" sx={{ mb: 2 }}>
+                                      Génération en cours. Tu peux quitter cette page : tu recevras une notification quand la leçon sera prête.
+                                    </Alert>
+                                  )}
+                                  {generationStatus === 'failed' && (
+                                    <Alert severity="error" sx={{ mb: 2 }}>
+                                      La génération de cette leçon a échoué. Réessaie plus tard.
+                                    </Alert>
+                                  )}
+                                  {!isLoading && !moleculeState.error && generationStatus !== 'pending' && (!moleculeState.atoms || moleculeState.atoms.length === 0) && (
+                                    <Alert severity="info">Les contenus de cette leçon sont encore en train d'être générés.</Alert>
+                                  )}
+                                  {moleculeState.atoms?.map((atom) => {
+                                    const type = (atom.content_type || '').toLowerCase();
+                                    return (
+                                      <ListItem key={atom.id} sx={{ pl: 0, alignItems: 'center' }}>
+                                        <ListItemIcon>
+                                          {type === 'lesson' ? <ArticleIcon color="primary" /> : <QuizIcon color="secondary" />}
+                                        </ListItemIcon>
+                                        <ListItemText primary={atom.title} secondary={type === 'lesson' ? 'Leçon' : 'Quiz'} />
+                                        <FeedbackButtons
+                                          contentType="atom"
+                                          contentId={atom.id}
+                                          initialRating={atom.user_feedback_rating}
+                                          initialReason={atom.user_feedback_reason}
+                                          initialComment={atom.user_feedback_comment}
+                                          onSuccess={() => {
+                                            queryClient.invalidateQueries({ queryKey: ['capsule', domain, area, capsuleId] });
+                                          }}
+                                        />
+                                      </ListItem>
+                                    );
+                                  })}
+                                </Box>
+                              </Collapse>
                             </Box>
-                          </Collapse>
-                        </Box>
-                      );
-                    })}
-                  </List>
-                </Collapse>
-              </Box>
-            );
-          })}
-        </List>
-      </Paper>
+                          );
+                        })}
+                      </List>
+                    </Collapse>
+                  </Box>
+                );
+              })}
+            </List>
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <CapsuleChatPanel domain={capsule.domain} area={capsule.area} capsuleTitle={capsule.title} />
+        </Grid>
+      </Grid>
     </Container>
   );
 };

--- a/src/features/chat/api/chatApi.js
+++ b/src/features/chat/api/chatApi.js
@@ -1,0 +1,97 @@
+import apiClient from '../../../api/axiosConfig';
+
+const DEFAULT_GENERAL_ROOM = {
+  id: 'general',
+  slug: 'general',
+  label: 'Chat général',
+  description: 'Discutez avec l’ensemble de la communauté.',
+  type: 'general',
+};
+
+const normalizeDomainRoom = (entry) => {
+  if (!entry) return null;
+  const domain = entry.domain || entry.id || entry.slug || entry.code;
+  if (!domain) return null;
+
+  const label = entry.label || entry.name || domain;
+  const description = entry.description || entry.details || '';
+  const areas = Array.isArray(entry.areas)
+    ? entry.areas
+    : Array.isArray(entry.available_areas)
+      ? entry.available_areas
+      : [];
+  const normalizedAreas = areas
+    .map((area) => (typeof area === 'string' ? area : area?.label || area?.name))
+    .filter(Boolean);
+
+  return {
+    id: entry.id || domain,
+    domain,
+    slug: entry.slug || domain,
+    label,
+    description,
+    areas: normalizedAreas,
+    activeUserCount:
+      entry.activeUserCount || entry.active_users_count || entry.active_users || entry.online_users || 0,
+  };
+};
+
+const extractRoomsFromPayload = (payload) => {
+  if (!payload || typeof payload !== 'object') {
+    return { general: DEFAULT_GENERAL_ROOM, domains: [] };
+  }
+
+  const generalSource =
+    payload.general ||
+    payload.room ||
+    (Array.isArray(payload.rooms)
+      ? payload.rooms.find((room) => room.type === 'general' || room.slug === 'general')
+      : null);
+
+  const domainsSource = Array.isArray(payload.domains)
+    ? payload.domains
+    : Array.isArray(payload.rooms)
+      ? payload.rooms.filter((room) => room.type === 'domain' || room.domain)
+      : [];
+
+  const general = generalSource
+    ? {
+        id: generalSource.id || generalSource.slug || 'general',
+        slug: generalSource.slug || generalSource.id || 'general',
+        label: generalSource.label || generalSource.name || DEFAULT_GENERAL_ROOM.label,
+        description: generalSource.description || generalSource.details || DEFAULT_GENERAL_ROOM.description,
+        type: 'general',
+      }
+    : DEFAULT_GENERAL_ROOM;
+
+  const domains = domainsSource
+    .map((entry) => normalizeDomainRoom(entry))
+    .filter(Boolean)
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return { general, domains };
+};
+
+export const fetchChatRooms = async () => {
+  const response = await apiClient.get('/chat/rooms');
+  const payload = response?.data ?? {};
+  return extractRoomsFromPayload(payload);
+};
+
+export const fetchChatHistory = async (roomId, params = {}) => {
+  if (!roomId) return [];
+  const response = await apiClient.get(`/chat/rooms/${encodeURIComponent(roomId)}/history`, {
+    params,
+  });
+  const messages = response?.data?.messages || response?.data || [];
+  return Array.isArray(messages) ? messages : [];
+};
+
+export const fetchDomainAreas = async (domain) => {
+  if (!domain) return [];
+  const response = await apiClient.get(`/chat/rooms/${encodeURIComponent(domain)}/areas`);
+  const areas = response?.data?.areas || response?.data || [];
+  return Array.isArray(areas)
+    ? areas.map((item) => (typeof item === 'string' ? item : item?.label || item?.name)).filter(Boolean)
+    : [];
+};

--- a/src/features/chat/components/ActiveUserList.jsx
+++ b/src/features/chat/components/ActiveUserList.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {
+  Avatar,
+  Chip,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Paper,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+const ActiveUserList = ({ users = [], status, variant = 'full' }) => {
+  const isLoading = status === 'connecting';
+  const displayUsers = Array.isArray(users) ? users : [];
+  const maxHeight = variant === 'embedded' ? 220 : 320;
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        flexShrink: 0,
+        width: { xs: '100%', md: variant === 'full' ? 260 : '100%' },
+        p: 2,
+        maxHeight,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+        <Typography variant="subtitle1">Utilisateurs actifs</Typography>
+        <Chip size="small" label={displayUsers.length} />
+      </Stack>
+      {isLoading ? (
+        <Stack spacing={1}>
+          <Skeleton variant="text" width="80%" />
+          <Skeleton variant="text" width="60%" />
+          <Skeleton variant="text" width="70%" />
+        </Stack>
+      ) : displayUsers.length > 0 ? (
+        <List dense sx={{ overflowY: 'auto' }}>
+          {displayUsers.map((user) => (
+            <ListItem key={user.id || user.username} sx={{ px: 0 }}>
+              <ListItemAvatar>
+                <Avatar>{(user.username || '?').charAt(0).toUpperCase()}</Avatar>
+              </ListItemAvatar>
+              <ListItemText
+                primary={user.username}
+                secondary={[user.area, user.domain].filter(Boolean).join(' • ') || undefined}
+              />
+            </ListItem>
+          ))}
+        </List>
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          Aucun utilisateur actif pour le moment.
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default ActiveUserList;

--- a/src/features/chat/components/CapsuleChatPanel.jsx
+++ b/src/features/chat/components/CapsuleChatPanel.jsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ForumIcon from '@mui/icons-material/Forum';
+import LaunchIcon from '@mui/icons-material/Launch';
+import { Link as RouterLink } from 'react-router-dom';
+import { ChatProvider } from '../context/ChatProvider';
+import ChatRoomView from './ChatRoomView';
+
+const formatDomainLabel = (value) => {
+  if (!value) return 'domaine';
+  const normalized = value.replace(/[-_]/g, ' ');
+  return normalized.replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
+const CapsuleChatPanel = ({ domain, area, capsuleTitle }) => {
+  const sanitizedDomain = domain || 'general';
+  const sanitizedArea = area || '';
+
+  const fullChatLink = useMemo(() => {
+    const base = `/chat/domain/${encodeURIComponent(sanitizedDomain)}`;
+    if (sanitizedArea) {
+      return `${base}?area=${encodeURIComponent(sanitizedArea)}`;
+    }
+    return base;
+  }, [sanitizedArea, sanitizedDomain]);
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Stack direction="row" spacing={1.5} alignItems="center">
+        <ForumIcon color="primary" />
+        <Box>
+          <Typography variant="h6">
+            Salon {formatDomainLabel(sanitizedDomain)}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Partagez vos questions sur « {capsuleTitle} » avec les autres apprenants du domaine.
+          </Typography>
+        </Box>
+      </Stack>
+      <Divider />
+      <ChatProvider>
+        <ChatRoomView
+          roomId={`domain:${sanitizedDomain}`}
+          domain={sanitizedDomain}
+          title={`Salon ${formatDomainLabel(sanitizedDomain)}`}
+          description={null}
+          defaultArea={sanitizedArea}
+          initialAreaFilter={sanitizedArea}
+          allowAreaSelection={false}
+          areaLocked
+          showActiveUsers
+          variant="embedded"
+          metadata={{ capsule: capsuleTitle }}
+        />
+      </ChatProvider>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          component={RouterLink}
+          to={fullChatLink}
+          variant="outlined"
+          endIcon={<LaunchIcon />}
+        >
+          Ouvrir le salon complet
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default CapsuleChatPanel;

--- a/src/features/chat/components/ChatComposer.jsx
+++ b/src/features/chat/components/ChatComposer.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+} from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+
+const ChatComposer = ({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+  placeholder,
+  areaOptions = [],
+  areaLocked = false,
+  selectedArea,
+  onAreaChange,
+}) => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (disabled) return;
+    onSubmit?.();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      if (!disabled) {
+        onSubmit?.();
+      }
+    }
+  };
+
+  const handleAreaChange = (event) => {
+    onAreaChange?.(event.target.value);
+  };
+
+  const areaSelectionEnabled = !areaLocked && areaOptions.length > 0;
+  const trimmedValue = value?.trim?.() || '';
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} noValidate>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems="flex-end">
+        {areaSelectionEnabled && (
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', sm: 160 } }}>
+            <InputLabel id="chat-area-select-label">Zone</InputLabel>
+            <Select
+              labelId="chat-area-select-label"
+              label="Zone"
+              value={selectedArea || ''}
+              onChange={handleAreaChange}
+            >
+              <MenuItem value="">Toutes les zones</MenuItem>
+              {areaOptions.map((area) => (
+                <MenuItem key={area} value={area}>
+                  {area}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+        <TextField
+          fullWidth
+          multiline
+          minRows={1}
+          maxRows={4}
+          placeholder={placeholder || 'Écrivez votre message…'}
+          value={value}
+          onChange={(event) => onChange?.(event.target.value)}
+          onKeyDown={handleKeyDown}
+          size="small"
+          disabled={disabled}
+        />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <IconButton
+            type="submit"
+            color="primary"
+            sx={{ display: { xs: 'inline-flex', sm: 'none' } }}
+            disabled={disabled || trimmedValue.length === 0}
+          >
+            <SendIcon />
+          </IconButton>
+          <Button
+            type="submit"
+            variant="contained"
+            endIcon={<SendIcon />}
+            disabled={disabled || trimmedValue.length === 0}
+            sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
+          >
+            Envoyer
+          </Button>
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ChatComposer;

--- a/src/features/chat/components/ChatLayout.jsx
+++ b/src/features/chat/components/ChatLayout.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, Paper } from '@mui/material';
+import { Outlet } from 'react-router-dom';
+import { ChatProvider } from '../context/ChatProvider';
+import useChatRoomsQuery from '../hooks/useChatRoomsQuery';
+import ChatSidebar from './ChatSidebar';
+
+const ChatLayout = () => {
+  const roomsQuery = useChatRoomsQuery();
+
+  return (
+    <ChatProvider>
+      <Paper
+        variant="outlined"
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          minHeight: { xs: 'auto', md: '70vh' },
+          width: '100%',
+        }}
+      >
+        <ChatSidebar
+          rooms={roomsQuery.data}
+          isLoading={roomsQuery.isLoading}
+          error={roomsQuery.error}
+        />
+        <Box sx={{ flex: 1, minWidth: 0, p: { xs: 2, md: 3 } }}>
+          <Outlet context={{ rooms: roomsQuery.data, roomsQuery }} />
+        </Box>
+      </Paper>
+    </ChatProvider>
+  );
+};
+
+export default ChatLayout;

--- a/src/features/chat/components/ChatMessageItem.jsx
+++ b/src/features/chat/components/ChatMessageItem.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Chip,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { alpha } from '@mui/material/styles';
+
+const formatChatTimestamp = (value) => {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: 'short',
+    }).format(date);
+  } catch (error) {
+    console.warn('Unable to format chat timestamp', error);
+    return date.toLocaleString();
+  }
+};
+
+const ChatMessageItem = ({ message, isOwn }) => {
+  const { username, content, domain, area, createdAt, system } = message;
+  const displayName = isOwn ? 'Vous' : username || 'Utilisateur';
+  const timestamp = formatChatTimestamp(createdAt);
+
+  if (system) {
+    return (
+      <Alert
+        severity="info"
+        icon={<InfoOutlinedIcon fontSize="small" />}
+        sx={{ alignSelf: 'center', maxWidth: '100%' }}
+      >
+        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+          {content}
+        </Typography>
+        {timestamp && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            {timestamp}
+          </Typography>
+        )}
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1.5}
+      alignItems="flex-start"
+      sx={{
+        alignSelf: isOwn ? 'flex-end' : 'flex-start',
+        maxWidth: '100%',
+        width: '100%',
+      }}
+    >
+      {!isOwn && (
+        <Avatar sx={{ bgcolor: (theme) => theme.palette.primary.main, fontSize: '0.875rem' }}>
+          {(username || '?').charAt(0).toUpperCase()}
+        </Avatar>
+      )}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{ mb: 0.5, flexWrap: 'wrap', rowGap: 0.5 }}
+        >
+          <Typography variant="subtitle2" color={isOwn ? 'primary.main' : 'text.primary'}>
+            {displayName}
+          </Typography>
+          {domain && (
+            <Chip label={domain} size="small" color="info" variant="outlined" />
+          )}
+          {area && (
+            <Chip label={area} size="small" color="secondary" variant="outlined" />
+          )}
+          {timestamp && (
+            <Typography variant="caption" color="text.secondary">
+              {timestamp}
+            </Typography>
+          )}
+        </Stack>
+        <Paper
+          elevation={0}
+          sx={{
+            p: 1.5,
+            borderRadius: 2,
+            border: 1,
+            borderColor: (theme) =>
+              isOwn ? alpha(theme.palette.primary.main, 0.4) : theme.palette.divider,
+            backgroundColor: (theme) =>
+              isOwn
+                ? alpha(theme.palette.primary.main, theme.palette.mode === 'dark' ? 0.3 : 0.12)
+                : theme.palette.background.paper,
+          }}
+        >
+          <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {content}
+          </Typography>
+        </Paper>
+      </Box>
+    </Stack>
+  );
+};
+
+export default ChatMessageItem;

--- a/src/features/chat/components/ChatMessageList.jsx
+++ b/src/features/chat/components/ChatMessageList.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import ChatMessageItem from './ChatMessageItem';
+
+const ChatMessageList = ({ messages, status, currentUsername }) => {
+  const bottomRef = useRef(null);
+  const isLoading = status === 'connecting';
+
+  useEffect(() => {
+    if (!bottomRef.current) return;
+    bottomRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const hasMessages = Array.isArray(messages) && messages.length > 0;
+
+  return (
+    <Box sx={{ flex: 1, overflowY: 'auto', pr: 1 }}>
+      {isLoading && !hasMessages && (
+        <Stack direction="row" justifyContent="center" sx={{ py: 3 }}>
+          <CircularProgress size={20} />
+        </Stack>
+      )}
+      {hasMessages ? (
+        <Stack spacing={1.5} sx={{ pb: 1 }}>
+          {messages.map((message) => (
+            <ChatMessageItem
+              key={message.id || `${message.username}-${message.createdAt}`}
+              message={message}
+              isOwn={Boolean(currentUsername) && message.username === currentUsername}
+            />
+          ))}
+          <Box ref={bottomRef} />
+        </Stack>
+      ) : (
+        !isLoading && (
+          <Stack spacing={1} sx={{ py: 4, alignItems: 'center', color: 'text.secondary' }}>
+            <Typography variant="body2">Aucun message pour le moment.</Typography>
+            <Typography variant="body2">Soyez la première personne à lancer la discussion !</Typography>
+          </Stack>
+        )
+      )}
+    </Box>
+  );
+};
+
+export default ChatMessageList;

--- a/src/features/chat/components/ChatRoomHeader.jsx
+++ b/src/features/chat/components/ChatRoomHeader.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+const STATUS_CONFIG = {
+  connecting: { label: 'Connexion…', color: 'info' },
+  connected: { label: 'Connecté', color: 'success' },
+  error: { label: 'Erreur', color: 'error' },
+  closed: { label: 'Déconnecté', color: 'default' },
+  idle: { label: 'Inactif', color: 'default' },
+};
+
+const ChatRoomHeader = ({
+  title,
+  description,
+  status,
+  areaFilter,
+  onAreaFilterChange,
+  areaOptions = [],
+  showAreaFilter = true,
+  lockedArea,
+  actions,
+  activeCount,
+}) => {
+  const statusConfig = STATUS_CONFIG[status] || STATUS_CONFIG.idle;
+  const hasAreaFilter = showAreaFilter && areaOptions.length > 0;
+
+  return (
+    <Stack
+      direction={{ xs: 'column', md: 'row' }}
+      spacing={2}
+      alignItems={{ xs: 'flex-start', md: 'center' }}
+      justifyContent="space-between"
+    >
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'wrap', rowGap: 1 }}>
+          <Typography variant="h5" sx={{ mr: 1 }}>
+            {title}
+          </Typography>
+          <Chip size="small" color={statusConfig.color} label={statusConfig.label} />
+          {typeof activeCount === 'number' && (
+            <Chip size="small" label={`${activeCount} en ligne`} />
+          )}
+          {lockedArea && (
+            <Chip size="small" color="secondary" label={`Zone : ${lockedArea}`} />
+          )}
+        </Stack>
+        {description && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {description}
+          </Typography>
+        )}
+      </Box>
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ width: { xs: '100%', md: 'auto' } }}>
+        {hasAreaFilter && (
+          <FormControl size="small" sx={{ minWidth: { xs: '100%', md: 200 } }}>
+            <InputLabel id="chat-room-area-filter">Filtrer par zone</InputLabel>
+            <Select
+              labelId="chat-room-area-filter"
+              label="Filtrer par zone"
+              value={areaFilter || ''}
+              onChange={(event) => onAreaFilterChange?.(event.target.value)}
+            >
+              <MenuItem value="">Toutes les zones</MenuItem>
+              {areaOptions.map((area) => (
+                <MenuItem key={area} value={area}>
+                  {area}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+        {actions && <Box sx={{ display: 'flex', alignItems: 'center' }}>{actions}</Box>}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default ChatRoomHeader;

--- a/src/features/chat/components/ChatRoomView.jsx
+++ b/src/features/chat/components/ChatRoomView.jsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Alert, Box, Paper, Stack } from '@mui/material';
+import { useAuth } from '../../../hooks/useAuth';
+import { useChatRoom } from '../context/ChatProvider';
+import ChatRoomHeader from './ChatRoomHeader';
+import ChatMessageList from './ChatMessageList';
+import ChatComposer from './ChatComposer';
+import ActiveUserList from './ActiveUserList';
+
+const normalizeArea = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const ChatRoomView = ({
+  roomId,
+  domain,
+  title,
+  description,
+  defaultArea,
+  initialAreaFilter,
+  onAreaFilterChange,
+  filterValue,
+  areaLocked = false,
+  allowAreaSelection = true,
+  availableAreas = [],
+  showActiveUsers = true,
+  variant = 'full',
+  metadata,
+}) => {
+  const { user } = useAuth();
+  const { messages, activeUsers, status, error, sendMessage } = useChatRoom(roomId, {
+    metadata: { domain, room: roomId, ...metadata },
+  });
+
+  const [composerValue, setComposerValue] = useState('');
+  const [internalFilter, setInternalFilter] = useState(normalizeArea(initialAreaFilter));
+  const [composerArea, setComposerArea] = useState(
+    normalizeArea(defaultArea) || normalizeArea(initialAreaFilter) || availableAreas[0] || ''
+  );
+
+  const effectiveFilter = filterValue !== undefined ? normalizeArea(filterValue) : internalFilter;
+
+  useEffect(() => {
+    setInternalFilter(normalizeArea(initialAreaFilter));
+  }, [initialAreaFilter]);
+
+  useEffect(() => {
+    if (!areaLocked && availableAreas.length > 0) {
+      if (!composerArea || !availableAreas.includes(composerArea)) {
+        setComposerArea(availableAreas[0]);
+      }
+    }
+  }, [areaLocked, availableAreas, composerArea]);
+
+  const areaOptions = useMemo(() => {
+    const options = new Set();
+    availableAreas.forEach((area) => {
+      if (typeof area === 'string' && area.trim()) options.add(area.trim());
+    });
+    messages?.forEach((message) => {
+      if (message.area) options.add(message.area);
+    });
+    return Array.from(options).sort((a, b) => a.localeCompare(b));
+  }, [availableAreas, messages]);
+
+  const filteredMessages = useMemo(() => {
+    if (!Array.isArray(messages)) return [];
+    if (!effectiveFilter) return messages;
+    return messages.filter((message) => message.area === effectiveFilter);
+  }, [effectiveFilter, messages]);
+
+  const canSend = status === 'connected';
+
+  const handleSubmit = () => {
+    const trimmed = composerValue.trim();
+    if (!trimmed) return;
+
+    const areaForMessage = areaLocked
+      ? normalizeArea(defaultArea)
+      : normalizeArea(composerArea || effectiveFilter || availableAreas[0] || '');
+
+    const payload = {
+      content: trimmed,
+      domain: domain || null,
+      area: areaForMessage || null,
+    };
+
+    try {
+      const result = sendMessage({ type: 'message', payload });
+      if (result) {
+        setComposerValue('');
+      }
+    } catch (sendError) {
+      console.error('Unable to send chat message', sendError);
+    }
+  };
+
+  const handleFilterChange = (nextValue) => {
+    const normalized = normalizeArea(nextValue);
+    if (filterValue === undefined) {
+      setInternalFilter(normalized);
+    }
+    onAreaFilterChange?.(normalized);
+  };
+
+  const errorMessage = error ? error.message || 'Le salon de discussion est indisponible.' : '';
+
+  return (
+    <Stack spacing={2} sx={{ height: '100%' }}>
+      <ChatRoomHeader
+        title={title}
+        description={description}
+        status={status}
+        areaFilter={effectiveFilter}
+        onAreaFilterChange={handleFilterChange}
+        areaOptions={areaOptions}
+        showAreaFilter={!areaLocked && allowAreaSelection}
+        lockedArea={areaLocked ? normalizeArea(defaultArea) : undefined}
+        activeCount={Array.isArray(activeUsers) ? activeUsers.length : undefined}
+      />
+      {errorMessage && (
+        <Alert severity="error">{errorMessage}</Alert>
+      )}
+      <Stack
+        direction={{ xs: 'column', md: variant === 'full' ? 'row' : 'column' }}
+        spacing={2}
+        sx={{ flex: 1, minHeight: variant === 'full' ? 400 : 320 }}
+      >
+        <Paper
+          variant="outlined"
+          sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 280 }}
+        >
+          <Box sx={{ flex: 1, overflow: 'hidden', p: 2 }}>
+            <ChatMessageList
+              messages={filteredMessages}
+              status={status}
+              currentUsername={user?.username}
+            />
+          </Box>
+          <Box sx={{ px: 2, py: 1.5, borderTop: (theme) => `1px solid ${theme.palette.divider}` }}>
+            <ChatComposer
+              value={composerValue}
+              onChange={setComposerValue}
+              onSubmit={handleSubmit}
+              disabled={!canSend}
+              areaOptions={allowAreaSelection ? areaOptions : []}
+              areaLocked={areaLocked || !allowAreaSelection}
+              selectedArea={composerArea}
+              onAreaChange={setComposerArea}
+            />
+          </Box>
+        </Paper>
+        {showActiveUsers && (
+          <ActiveUserList users={activeUsers} status={status} variant={variant} />
+        )}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default ChatRoomView;

--- a/src/features/chat/components/ChatSidebar.jsx
+++ b/src/features/chat/components/ChatSidebar.jsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ForumIcon from '@mui/icons-material/Forum';
+import InterestsIcon from '@mui/icons-material/Interests';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { useChatContext } from '../context/ChatProvider';
+
+const isPathActive = (currentPath, targetPath) => {
+  if (targetPath === '/chat') {
+    return currentPath === '/chat' || currentPath === '/chat/';
+  }
+  return currentPath.startsWith(targetPath);
+};
+
+const ChatSidebar = ({ rooms, isLoading, error }) => {
+  const location = useLocation();
+  const { rooms: activeRooms } = useChatContext();
+
+  const domainRooms = rooms?.domains || [];
+  const generalRoom = rooms?.general || {
+    label: 'Chat général',
+    description: 'Discutez avec tout le monde.',
+    slug: 'general',
+  };
+
+  const activeCounts = useMemo(() => {
+    const map = new Map();
+    Object.entries(activeRooms || {}).forEach(([roomId, roomState]) => {
+      if (roomState?.activeUsers) {
+        map.set(roomId, roomState.activeUsers.length);
+      }
+    });
+    return map;
+  }, [activeRooms]);
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        width: { xs: '100%', md: 280 },
+        borderRight: { md: (theme) => `1px solid ${theme.palette.divider}` },
+      }}
+    >
+      <Box sx={{ px: 2.5, py: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          Salons
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Rejoignez le chat général ou les salons par domaine.
+        </Typography>
+      </Box>
+      <Divider />
+      <List component="nav" disablePadding>
+        <ListItemButton
+          component={RouterLink}
+          to="/chat"
+          selected={isPathActive(location.pathname, '/chat') && !location.pathname.startsWith('/chat/domain')}
+        >
+          <ListItemIcon>
+            <ForumIcon />
+          </ListItemIcon>
+          <ListItemText
+            primary={generalRoom.label || 'Chat général'}
+            secondary={generalRoom.description || 'Espace commun pour toutes les discussions.'}
+          />
+        </ListItemButton>
+      </List>
+      <Divider textAlign="left" sx={{ mt: 1 }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ color: 'text.secondary' }}>
+          <InterestsIcon fontSize="small" />
+          <Typography variant="caption" sx={{ textTransform: 'uppercase', letterSpacing: 0.6 }}>
+            Domaines
+          </Typography>
+        </Stack>
+      </Divider>
+      <Box sx={{ px: 1 }}>
+        {isLoading ? (
+          <Stack alignItems="center" sx={{ py: 3 }}>
+            <CircularProgress size={20} />
+          </Stack>
+        ) : error ? (
+          <Typography variant="body2" color="error" sx={{ px: 1, py: 2 }}>
+            Impossible de charger la liste des salons.
+          </Typography>
+        ) : domainRooms.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ px: 1, py: 2 }}>
+            Aucun domaine disponible pour le moment.
+          </Typography>
+        ) : (
+          <List dense disablePadding>
+            {domainRooms.map((room) => {
+              const domainSlug = encodeURIComponent(room.slug || room.domain || room.id);
+              const to = `/chat/domain/${domainSlug}`;
+              const roomId = `domain:${room.domain || room.slug || room.id}`;
+              const activeCount = activeCounts.get(roomId) ?? room.activeUserCount ?? 0;
+              return (
+                <ListItemButton
+                  key={roomId}
+                  component={RouterLink}
+                  to={to}
+                  selected={isPathActive(location.pathname, to)}
+                  sx={{ borderRadius: 1, mb: 0.5 }}
+                >
+                  <ListItemIcon sx={{ minWidth: 36 }}>
+                    <InterestsIcon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={room.label || room.domain || room.id}
+                    secondary={room.description}
+                    secondaryTypographyProps={{ noWrap: true }}
+                  />
+                  {activeCount > 0 && (
+                    <Typography variant="caption" color="text.secondary">{activeCount}</Typography>
+                  )}
+                </ListItemButton>
+              );
+            })}
+          </List>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default ChatSidebar;

--- a/src/features/chat/context/ChatProvider.jsx
+++ b/src/features/chat/context/ChatProvider.jsx
@@ -1,0 +1,381 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { buildChatSocketUrl } from '../../../config/api';
+
+const ChatContext = createContext(null);
+
+const createInitialRoomState = () => ({
+  status: 'idle',
+  error: null,
+  messages: [],
+  activeUsers: [],
+  metadata: {},
+  refCount: 0,
+  lastEventAt: null,
+  hasHistory: false,
+});
+
+const toError = (value) => {
+  if (!value) return null;
+  if (value instanceof Error) return value;
+  if (typeof value === 'string') return new Error(value);
+  if (typeof value === 'object' && value.message) return new Error(value.message);
+  return new Error('Une erreur inconnue est survenue.');
+};
+
+const eventTypeMatches = (type, expected) => {
+  if (!type) return false;
+  if (type === expected) return true;
+  return type === `chat.${expected}`;
+};
+
+const normalizeMessage = (raw) => {
+  if (!raw) return null;
+  const source = raw.payload || raw.message || raw;
+  if (!source) return null;
+
+  const username = source.username || source.user?.username || source.author || 'Utilisateur';
+  const id =
+    source.id ||
+    source.message_id ||
+    source.uuid ||
+    source._id ||
+    `${username}-${source.created_at || source.timestamp || Date.now()}`;
+  const createdAt =
+    source.created_at || source.createdAt || source.timestamp || source.sent_at || new Date().toISOString();
+  const content = source.content || source.message || source.text || '';
+  const domain = source.domain || source.room?.domain || source.metadata?.domain || null;
+  const area = source.area || source.topic_area || source.metadata?.area || null;
+  const system = Boolean(source.system || source.type === 'system');
+
+  return {
+    id,
+    username,
+    content,
+    domain,
+    area,
+    createdAt,
+    system,
+    userId: source.user_id || source.userId || source.user?.id || null,
+  };
+};
+
+const normalizeUser = (raw) => {
+  if (!raw) return null;
+  const username = raw.username || raw.name || raw.display_name || raw.user?.username;
+  if (!username) return null;
+  return {
+    id: raw.id || raw.user_id || username,
+    username,
+    avatar: raw.avatar || raw.avatar_url || raw.user?.avatar || null,
+    domain: raw.domain || raw.room?.domain || null,
+    area: raw.area || raw.topic_area || null,
+    status: raw.status || 'online',
+  };
+};
+
+const mergeMessages = (current = [], incoming = []) => {
+  if (!incoming || incoming.length === 0) return current;
+  const registry = new Map();
+  current.forEach((message) => {
+    const key = message.id || `${message.username}-${message.createdAt}`;
+    registry.set(key, message);
+  });
+  incoming.forEach((message) => {
+    if (!message) return;
+    const key = message.id || `${message.username}-${message.createdAt}`;
+    registry.set(key, { ...(registry.get(key) || {}), ...message });
+  });
+  return Array.from(registry.values()).sort((a, b) => {
+    const left = new Date(a.createdAt).getTime();
+    const right = new Date(b.createdAt).getTime();
+    return left - right;
+  });
+};
+
+export const ChatProvider = ({ children }) => {
+  const [rooms, setRooms] = useState({});
+  const socketsRef = useRef(new Map());
+
+  const handleIncoming = useCallback((roomId, rawData) => {
+    if (!rawData) return;
+    let parsed;
+    if (typeof rawData === 'string') {
+      try {
+        parsed = JSON.parse(rawData);
+      } catch (error) {
+        console.warn('Unable to parse chat payload', error, rawData);
+        return;
+      }
+    } else if (typeof rawData === 'object') {
+      parsed = rawData;
+    } else {
+      return;
+    }
+
+    setRooms((prev) => {
+      const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+      const next = { ...current, lastEventAt: Date.now() };
+
+      const payload = parsed.payload ?? parsed;
+      const type = parsed.type || parsed.event || payload?.type;
+
+      if (Array.isArray(parsed) || Array.isArray(payload?.messages)) {
+        const history = (Array.isArray(parsed) ? parsed : payload.messages)
+          .map((item) => normalizeMessage(item))
+          .filter(Boolean);
+        next.messages = mergeMessages(current.messages, history);
+        next.hasHistory = true;
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventTypeMatches(type, 'message') || (!type && payload && (payload.content || payload.message))) {
+        const message = normalizeMessage(payload);
+        if (!message) return prev;
+        next.messages = mergeMessages(current.messages, [message]);
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventTypeMatches(type, 'history')) {
+        const history = (payload?.messages || payload || [])
+          .map((item) => normalizeMessage(item))
+          .filter(Boolean);
+        next.messages = mergeMessages(current.messages, history);
+        next.hasHistory = true;
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventTypeMatches(type, 'users')) {
+        const users = (payload?.users || payload || [])
+          .map((item) => normalizeUser(item))
+          .filter(Boolean);
+        next.activeUsers = users;
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventTypeMatches(type, 'error')) {
+        next.error = toError(payload?.error || payload);
+        next.status = 'error';
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventTypeMatches(type, 'system')) {
+        const message = normalizeMessage({ ...payload, system: true });
+        if (!message) return prev;
+        next.messages = mergeMessages(current.messages, [message]);
+        return { ...prev, [roomId]: next };
+      }
+
+      if (payload?.content || payload?.message) {
+        const message = normalizeMessage(payload);
+        if (!message) return prev;
+        next.messages = mergeMessages(current.messages, [message]);
+        return { ...prev, [roomId]: next };
+      }
+
+      return prev;
+    });
+  }, []);
+
+  const closeSocket = useCallback((roomId, code = 1000, reason = 'client-leave') => {
+    const socket = socketsRef.current.get(roomId);
+    if (!socket) return;
+    try {
+      socket.close(code, reason);
+    } catch (error) {
+      console.warn('Unable to close chat socket', error);
+    }
+    socketsRef.current.delete(roomId);
+  }, []);
+
+  const connectSocket = useCallback(
+    (roomId, metadata = {}) => {
+      if (!roomId || socketsRef.current.has(roomId)) return;
+      let socket;
+      try {
+        socket = new WebSocket(buildChatSocketUrl(roomId, metadata));
+      } catch (error) {
+        console.error('Unable to create chat socket', error);
+        setRooms((prev) => {
+          const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+          return {
+            ...prev,
+            [roomId]: { ...current, status: 'error', error: toError(error) },
+          };
+        });
+        return;
+      }
+
+      socketsRef.current.set(roomId, socket);
+
+      setRooms((prev) => {
+        const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+        return {
+          ...prev,
+          [roomId]: {
+            ...current,
+            status: 'connecting',
+            error: null,
+            metadata: { ...current.metadata, ...metadata },
+          },
+        };
+      });
+
+      socket.onopen = () => {
+        setRooms((prev) => {
+          const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+          return {
+            ...prev,
+            [roomId]: { ...current, status: 'connected', error: null },
+          };
+        });
+        if (metadata && Object.keys(metadata).length > 0) {
+          try {
+            socket.send(JSON.stringify({ type: 'join', payload: metadata }));
+          } catch (error) {
+            console.warn('Unable to send join metadata', error);
+          }
+        }
+      };
+
+      socket.onmessage = (event) => {
+        handleIncoming(roomId, event.data);
+      };
+
+      socket.onerror = (event) => {
+        console.error('Chat socket error', event);
+        setRooms((prev) => {
+          const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+          return {
+            ...prev,
+            [roomId]: { ...current, status: 'error', error: toError(event) },
+          };
+        });
+      };
+
+      socket.onclose = (event) => {
+        socketsRef.current.delete(roomId);
+        setRooms((prev) => {
+          const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+          return {
+            ...prev,
+            [roomId]: {
+              ...current,
+              status: event.wasClean ? 'closed' : 'error',
+              error: event.wasClean ? current.error : current.error || new Error(`Connexion perdue (${event.code})`),
+            },
+          };
+        });
+      };
+    },
+    [handleIncoming]
+  );
+
+  const joinRoom = useCallback(
+    (roomId, options = {}) => {
+      if (!roomId) return;
+      const metadata = options.metadata || {};
+      setRooms((prev) => {
+        const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
+        return {
+          ...prev,
+          [roomId]: {
+            ...current,
+            refCount: (current.refCount || 0) + 1,
+            metadata: { ...current.metadata, ...metadata },
+          },
+        };
+      });
+      if (!socketsRef.current.has(roomId)) {
+        connectSocket(roomId, metadata);
+      }
+    },
+    [connectSocket]
+  );
+
+  const leaveRoom = useCallback((roomId) => {
+    if (!roomId) return;
+    setRooms((prev) => {
+      const current = prev[roomId];
+      if (!current) return prev;
+      const nextCount = Math.max(0, (current.refCount || 1) - 1);
+      if (nextCount > 0) {
+        return {
+          ...prev,
+          [roomId]: { ...current, refCount: nextCount },
+        };
+      }
+      closeSocket(roomId);
+      return {
+        ...prev,
+        [roomId]: { ...current, refCount: 0, status: 'idle' },
+      };
+    });
+  }, [closeSocket]);
+
+  const sendMessageInternal = useCallback((roomId, message) => {
+    const socket = socketsRef.current.get(roomId);
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Le salon de discussion n’est pas connecté.');
+    }
+    const payload = message && message.type ? message : { type: 'message', payload: message };
+    socket.send(JSON.stringify(payload));
+    return true;
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      rooms,
+      joinRoom,
+      leaveRoom,
+      sendMessage: sendMessageInternal,
+    }),
+    [joinRoom, leaveRoom, rooms, sendMessageInternal]
+  );
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+};
+
+export const useChatContext = () => {
+  const context = useContext(ChatContext);
+  if (!context) {
+    throw new Error('useChatContext must be used within a ChatProvider');
+  }
+  return context;
+};
+
+export const useChatRoom = (roomId, { metadata, autoJoin = true } = {}) => {
+  const { rooms, joinRoom, leaveRoom, sendMessage } = useChatContext();
+  const metadataRef = useRef(metadata);
+  metadataRef.current = metadata;
+
+  useEffect(() => {
+    if (!autoJoin || !roomId) return undefined;
+    joinRoom(roomId, { metadata: metadataRef.current });
+    return () => {
+      leaveRoom(roomId);
+    };
+  }, [autoJoin, joinRoom, leaveRoom, roomId]);
+
+  const roomState = rooms[roomId] || createInitialRoomState();
+
+  const send = useCallback(
+    (payload) => {
+      if (!roomId) return false;
+      return sendMessage(roomId, payload);
+    },
+    [roomId, sendMessage]
+  );
+
+  return {
+    ...roomState,
+    sendMessage: send,
+  };
+};

--- a/src/features/chat/hooks/useChatRoomsQuery.js
+++ b/src/features/chat/hooks/useChatRoomsQuery.js
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchChatRooms } from '../api/chatApi';
+
+export const useChatRoomsQuery = () =>
+  useQuery({
+    queryKey: ['chat', 'rooms'],
+    queryFn: fetchChatRooms,
+    staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+export default useChatRoomsQuery;

--- a/src/features/chat/pages/DomainChatPage.jsx
+++ b/src/features/chat/pages/DomainChatPage.jsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import { useOutletContext, useParams, useSearchParams } from 'react-router-dom';
+import ChatRoomView from '../components/ChatRoomView';
+
+const formatDomainLabel = (value) => {
+  if (!value) return 'Salon de discussion';
+  const normalized = value.replace(/[-_]/g, ' ');
+  return normalized.replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
+const DomainChatPage = () => {
+  const { domainId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const outletContext = useOutletContext() || {};
+  const rooms = outletContext.rooms || {};
+
+  const decodedDomain = useMemo(() => {
+    try {
+      return decodeURIComponent(domainId || '');
+    } catch (error) {
+      console.warn('Unable to decode domain identifier', error);
+      return domainId || '';
+    }
+  }, [domainId]);
+
+  const domainRoom = useMemo(() => {
+    if (!Array.isArray(rooms?.domains)) return null;
+    return (
+      rooms.domains.find((room) => {
+        const key = room.slug || room.domain || room.id;
+        return key === decodedDomain;
+      }) || null
+    );
+  }, [decodedDomain, rooms?.domains]);
+
+  const initialArea = searchParams.get('area') || domainRoom?.areas?.[0] || '';
+
+  const handleFilterChange = (nextValue) => {
+    const params = new URLSearchParams(searchParams);
+    if (nextValue) {
+      params.set('area', nextValue);
+    } else {
+      params.delete('area');
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  const roomKey = domainRoom?.domain || domainRoom?.slug || decodedDomain;
+
+  return (
+    <ChatRoomView
+      roomId={`domain:${roomKey}`}
+      domain={roomKey}
+      title={domainRoom?.label || formatDomainLabel(decodedDomain)}
+      description={domainRoom?.description || 'Échangez avec les apprenants de ce domaine.'}
+      defaultArea={domainRoom?.areas?.includes(initialArea) ? initialArea : domainRoom?.areas?.[0]}
+      initialAreaFilter={initialArea}
+      onAreaFilterChange={handleFilterChange}
+      availableAreas={domainRoom?.areas || []}
+      allowAreaSelection
+      showActiveUsers
+      variant="full"
+    />
+  );
+};
+
+export default DomainChatPage;

--- a/src/features/chat/pages/GeneralChatPage.jsx
+++ b/src/features/chat/pages/GeneralChatPage.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useOutletContext } from 'react-router-dom';
+import ChatRoomView from '../components/ChatRoomView';
+
+const GeneralChatPage = () => {
+  const outletContext = useOutletContext() || {};
+  const rooms = outletContext.rooms || {};
+  const general = rooms.general || {
+    label: 'Chat général',
+    description: 'Discutez avec l’ensemble de la communauté.',
+  };
+
+  return (
+    <ChatRoomView
+      roomId="general"
+      domain="general"
+      title={general.label || 'Chat général'}
+      description={general.description || 'Discutez avec l’ensemble de la communauté.'}
+      allowAreaSelection={false}
+      showActiveUsers
+      variant="full"
+    />
+  );
+};
+
+export default GeneralChatPage;


### PR DESCRIPTION
## Summary
- expose a dedicated chat websocket URL builder for client connections
- scaffold chat provider, layout, and room components with routes for general and domain salons
- embed the domain chat panel inside capsule details and add REST helpers for chat metadata

## Testing
- npm run lint *(fails: existing lint violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d142120b5c8327920eaf09e55b4a58