### PR TITLE
Ensure authenticated requests forward cookies

### DIFF
--- a/src/features/authentication/api/emailClient.js
+++ b/src/features/authentication/api/emailClient.js
@@ -9,7 +9,9 @@ async function postJSON(url, body) {
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
+    // indispensable pour que le cookie access_token suive les requêtes protégées
+    credentials: 'include'
   });
   if (!res.ok) {
     let detail = 'Unexpected error';

--- a/src/features/authentication/emailClient.js
+++ b/src/features/authentication/emailClient.js
@@ -9,7 +9,9 @@ async function postJSON(url, body) {
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
+    // indispensable pour que le cookie access_token suive les requêtes protégées
+    credentials: 'include'
   });
   if (!res.ok) {
     let detail = 'Unexpected error';

--- a/src/pages/legal/ReportContentPage.tsx
+++ b/src/pages/legal/ReportContentPage.tsx
@@ -78,7 +78,9 @@ export default function ReportContentPage() {
       const response = await fetch(buildApiUrl('/legal/report'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
+        // Active l'envoi du cookie access_token si l'utilisateur est authentifié
+        credentials: 'include'
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- add `credentials: 'include'` to every fetch helper so JWT cookies travel with protected requests
- update the legal report form to include credentials when posting data

## Testing
- npm run lint *(fails: existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d46e172de8832781527ffa0483dc92