### PR TITLE
Add axios debug logging

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -8,7 +8,44 @@ const apiClient = axios.create({
   withCredentials: true,
 });
 
-// On a supprimé tout le bloc "apiClient.interceptors.request.use(...)"
-// car le navigateur gère maintenant le token pour nous.
+apiClient.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    console.debug('[API][request]', {
+      url: config.url,
+      method: config.method,
+      withCredentials: config.withCredentials,
+      cookies: document.cookie,
+      headers: config.headers,
+    });
+  }
+
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => {
+    if (typeof window !== 'undefined') {
+      console.debug('[API][response]', {
+        url: response.config?.url,
+        status: response.status,
+        data: response.data,
+      });
+    }
+
+    return response;
+  },
+  (error) => {
+    if (typeof window !== 'undefined') {
+      console.error('[API][response][error]', {
+        url: error.config?.url,
+        status: error.response?.status,
+        data: error.response?.data,
+        headers: error.config?.headers,
+      });
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;


### PR DESCRIPTION
## Summary
- add request and response interceptors to axios client so we can inspect cookies, headers and payloads when calls to the API are made

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d470b76d5483278f63b93fc9d88170