### PR TITLE
Add local storage fallback for API authentication

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,6 +2,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import apiClient from '../api/axiosConfig';
 import { useWebSocket } from '../contexts/WebSocketProvider';
+import { clearStoredAccessToken, setStoredAccessToken } from '../utils/authTokens';
 
 const fetchUser = async () => {
   try {
@@ -16,9 +17,13 @@ const loginUser = async (credentials) => {
   const formData = new URLSearchParams();
   formData.append('username', credentials.username);
   formData.append('password', credentials.password);
+  clearStoredAccessToken();
   const { data } = await apiClient.post('/users/login', formData, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   });
+  if (data?.access_token) {
+    setStoredAccessToken(data.access_token);
+  }
   return data;
 };
 
@@ -53,6 +58,7 @@ const registerUser = async (userData = {}) => {
 
 const logoutUser = async () => {
   const { data } = await apiClient.post('/users/logout');
+  clearStoredAccessToken();
   return data;
 };
 

--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -1,0 +1,33 @@
+// src/utils/authTokens.js
+// Centralise the logic used to persist the access token returned by the API
+// when cookies are not available (e.g. during local development over HTTP).
+
+const STORAGE_KEY = 'nanshe.access_token';
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export const getStoredAccessToken = () => {
+  if (!isBrowser()) {
+    return null;
+  }
+  return window.localStorage.getItem(STORAGE_KEY);
+};
+
+export const setStoredAccessToken = (token) => {
+  if (!isBrowser()) {
+    return;
+  }
+  if (token) {
+    window.localStorage.setItem(STORAGE_KEY, token);
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+};
+
+export const clearStoredAccessToken = () => {
+  if (!isBrowser()) {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+};
+


### PR DESCRIPTION
## Summary
- add an auth token storage helper to keep the access token in localStorage when cookies are unavailable
- inject the stored token into axios requests and clear it when a 401 response is received
- persist and clear the token during login/logout mutations so authenticated calls succeed without relying on cookies

## Testing
- npx eslint src/api/axiosConfig.js src/hooks/useAuth.js src/utils/authTokens.js

------
https://chatgpt.com/codex/tasks/task_e_68d472844aa08327b532898a9dd824ad