### PR TITLE
feat: open domain chat from dashboard capsules

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -89,6 +89,7 @@
       "lessons": "{{count}} lessons",
       "durationHours": "{{count}} hrs",
       "xpValue": "{{current}} / {{target}} XP",
+      "chatAriaLabel": "Open the domain chat",
       "categories": {
         "language": "Language & Culture",
         "design": "Design & Creativity",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -89,6 +89,7 @@
       "lessons": "{{count}} leçons",
       "durationHours": "{{count}} h",
       "xpValue": "{{current}} / {{target}} XP",
+      "chatAriaLabel": "Ouvrir le salon du domaine",
       "categories": {
         "language": "Langues & Culture",
         "design": "Design & Créativité",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -89,6 +89,7 @@
       "lessons": "{{count}} lessen",
       "durationHours": "{{count}} u",
       "xpValue": "{{current}} / {{target}} XP",
+      "chatAriaLabel": "Domeinchat openen",
       "categories": {
         "language": "Taal & Cultuur",
         "design": "Design & Creativiteit",


### PR DESCRIPTION
## Summary
- replace the dashboard capsule coach shortcut with navigation to the relevant domain chat room
- adjust the capsule card chat icon handling and aria label to reflect the chat entry point
- add i18n strings for the new chat aria label in English, French, and Dutch

## Testing
- npm run lint *(fails: existing lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4785354508327a5c045ab1260530d