### PR TITLE
Update frontend to use conversations WebSocket endpoint

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -99,14 +99,14 @@ export const CHAT_WS_URL = (() => {
   try {
     const base = new URL(API_WS_URL);
     const trimmedPath = base.pathname.replace(/\/+$/, '');
-    const hasChatSuffix = /\/chat$/.test(trimmedPath);
-    base.pathname = hasChatSuffix ? trimmedPath : `${trimmedPath}/chat`;
+    const hasConversationSuffix = /\/conversations$/.test(trimmedPath);
+    base.pathname = hasConversationSuffix ? trimmedPath : `${trimmedPath}/conversations`;
     base.search = '';
     base.hash = '';
     return base.toString();
   } catch (error) {
     console.warn('Unable to derive Chat WebSocket URL from API_WS_URL. Falling back to localhost.', error);
-    return 'ws://localhost:8000/api/v2/ws/chat';
+    return 'ws://localhost:8000/api/v2/ws/conversations';
   }
 })();
 
@@ -116,7 +116,8 @@ export const buildChatSocketUrl = (room, params = {}) => {
     if (room) {
       url.searchParams.set('room', room);
     }
-    Object.entries(params || {}).forEach(([key, value]) => {
+    const entries = Object.entries(params || {});
+    entries.forEach(([key, value]) => {
       if (value === undefined || value === null) return;
       const stringValue = typeof value === 'string' ? value : String(value);
       if (stringValue.length === 0) return;

--- a/src/features/chat/components/ChatRoomView.jsx
+++ b/src/features/chat/components/ChatRoomView.jsx
@@ -26,8 +26,35 @@ const ChatRoomView = ({
   metadata,
 }) => {
   const { user } = useAuth();
+  const connectionMetadata = useMemo(() => {
+    const baseMetadata = metadata && typeof metadata === 'object' ? metadata : {};
+    const normalizedDomain =
+      (typeof domain === 'string' && domain.trim()) || baseMetadata.domain || 'general';
+    const candidateArea =
+      baseMetadata.area ||
+      defaultArea ||
+      initialAreaFilter ||
+      (Array.isArray(availableAreas) && availableAreas.length > 0 ? availableAreas[0] : '') ||
+      'general';
+    const normalizedArea = normalizeArea(candidateArea);
+
+    const nextMetadata = {
+      ...baseMetadata,
+      domain: normalizedDomain,
+      room: roomId,
+    };
+
+    if (normalizedArea) {
+      nextMetadata.area = normalizedArea;
+    } else if ('area' in nextMetadata) {
+      delete nextMetadata.area;
+    }
+
+    return nextMetadata;
+  }, [metadata, domain, roomId, defaultArea, initialAreaFilter, availableAreas]);
+
   const { messages, activeUsers, status, error, sendMessage } = useChatRoom(roomId, {
-    metadata: { domain, room: roomId, ...metadata },
+    metadata: connectionMetadata,
   });
 
   const [composerValue, setComposerValue] = useState('');


### PR DESCRIPTION
## Summary
- update the chat WebSocket URL helpers to point to the `/api/v2/ws/conversations` route
- propagate chat metadata to always send domain and area query parameters when connecting

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d480e6f3a08327a9484646a91686a1