### PR TITLE
Persist user profile customizations

### DIFF
--- a/src/utils/userProfileStorage.js
+++ b/src/utils/userProfileStorage.js
@@ -1,0 +1,51 @@
+// src/utils/userProfileStorage.js
+// Handle persisting the authenticated user profile between sessions so that
+// customisations like avatar frames or titles remain visible after a reload.
+
+const STORAGE_KEY = 'nanshe.user_profile';
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export const getStoredUserProfile = () => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY);
+    return value ? JSON.parse(value) : null;
+  } catch (error) {
+    console.warn('[userProfileStorage] Failed to read stored profile', error);
+    return null;
+  }
+};
+
+export const setStoredUserProfile = (profile) => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  if (!profile || typeof profile !== 'object') {
+    clearStoredUserProfile();
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+  } catch (error) {
+    console.warn('[userProfileStorage] Failed to persist profile', error);
+  }
+};
+
+export const clearStoredUserProfile = () => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.warn('[userProfileStorage] Failed to clear stored profile', error);
+  }
+};
+


### PR DESCRIPTION
## Summary
- add a small storage helper to persist the authenticated user profile in local storage
- make the authentication hook hydrate the user from storage and keep it in sync with the latest profile data
- ensure the cached profile is cleared on logout so dashboard components always reflect the stored customisations

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fdbbc300832798e3b369bb79764c