### PR TITLE
Use cookie-backed access token storage

### DIFF
--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -3,8 +3,29 @@
 // when cookies are not available (e.g. during local development over HTTP).
 
 const STORAGE_KEY = 'nanshe.access_token';
+const COOKIE_NAME = 'access_token';
 
-const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+const isBrowser = () => typeof window !== 'undefined';
+const hasLocalStorage = () => isBrowser() && typeof window.localStorage !== 'undefined';
+
+const getCookieValue = (name) => {
+  if (!isBrowser() || typeof document === 'undefined') {
+    return null;
+  }
+
+  const cookies = document.cookie ?? '';
+  const match = cookies
+    .split(';')
+    .map((part) => part.trim())
+    .find((cookie) => cookie.startsWith(`${name}=`));
+
+  if (!match) {
+    return null;
+  }
+
+  const value = match.slice(name.length + 1);
+  return value ? decodeURIComponent(value) : null;
+};
 
 export const getStoredAccessToken = () => {
   if (!isBrowser()) {
@@ -12,9 +33,22 @@ export const getStoredAccessToken = () => {
     return null;
   }
 
+  const cookieToken = getCookieValue(COOKIE_NAME);
+  if (cookieToken) {
+    console.debug('[AuthTokens] Retrieved access token from cookie.', {
+      length: cookieToken.length,
+    });
+    return cookieToken;
+  }
+
+  if (!hasLocalStorage()) {
+    console.debug('[AuthTokens] No cookies available and localStorage is unsupported.');
+    return null;
+  }
+
   const rawValue = window.localStorage.getItem(STORAGE_KEY);
   if (rawValue) {
-    console.debug('[AuthTokens] Retrieved access token from storage.', {
+    console.debug('[AuthTokens] Retrieved access token from localStorage fallback.', {
       length: rawValue.length,
     });
   } else {
@@ -30,11 +64,27 @@ export const setStoredAccessToken = (token) => {
     return;
   }
 
+  const cookieToken = getCookieValue(COOKIE_NAME);
+  if (cookieToken) {
+    console.info('[AuthTokens] Access token provided via cookie; skipping localStorage fallback.', {
+      length: cookieToken.length,
+    });
+    if (hasLocalStorage()) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+    return;
+  }
+
+  if (!hasLocalStorage()) {
+    console.warn('[AuthTokens] Cannot persist access token: no cookie detected and localStorage unavailable.');
+    return;
+  }
+
   const normalizedToken = typeof token === 'string' ? token.trim() : '';
 
   if (normalizedToken) {
     window.localStorage.setItem(STORAGE_KEY, normalizedToken);
-    console.info('[AuthTokens] Stored access token in localStorage.', {
+    console.info('[AuthTokens] Stored access token in localStorage fallback.', {
       length: normalizedToken.length,
     });
   } else {
@@ -49,7 +99,14 @@ export const clearStoredAccessToken = () => {
     return;
   }
 
-  window.localStorage.removeItem(STORAGE_KEY);
-  console.info('[AuthTokens] Access token removed from localStorage.');
+  if (typeof document !== 'undefined') {
+    document.cookie = `${COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax;`;
+    console.info('[AuthTokens] Requested browser to remove access token cookie.');
+  }
+
+  if (hasLocalStorage()) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    console.info('[AuthTokens] Access token removed from localStorage fallback.');
+  }
 };
 


### PR DESCRIPTION
## Summary
- read the access token from the secure `access_token` cookie before falling back to localStorage
- skip localStorage persistence when the cookie is present and attempt to clear the cookie on logout

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d501372ab883278d2b795e8f55ca96