### PR TITLE
Delay WebSocket connection until user authenticated

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -103,6 +103,18 @@ export const useAuth = () => {
     }
   }, [user, isLoading]);
 
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+
+    if (user) {
+      reconnect();
+    } else {
+      disconnect();
+    }
+  }, [user, isLoading, reconnect, disconnect]);
+
   // Après login: invalidation + refetch de l'utilisateur, puis reconnect WS
   const loginMutation = useMutation({
     mutationFn: loginUser,


### PR DESCRIPTION
## Summary
- prevent the shared WebSocket from opening automatically when no session token is available and add guarded reconnection/cleanup paths
- automatically trigger WebSocket connect/disconnect from the auth hook once the user profile is resolved, keeping sockets closed for anonymous visitors

## Testing
- npm run lint *(fails: repository currently has unrelated lint errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68d50d6260b083279cc0dd42f336ca43