### PR TITLE
Fix login token storage after authentication

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -87,11 +87,15 @@ const loginUser = async (credentials) => {
   const { data } = await apiClient.post('/users/login', formData, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
   });
-  const accessToken = resolveAccessToken(data);
+  const directToken = typeof data === 'object' && data !== null ? data.access_token : null;
+  const accessToken = resolveAccessToken(directToken ?? data);
+
   if (typeof accessToken === 'string' && accessToken.trim()) {
     setStoredAccessToken(accessToken);
   } else {
-    console.warn('[Auth] Login succeeded but no access token was found in response payload.');
+    console.warn('[Auth] Login succeeded but no access token was found in response payload.', {
+      payloadKeys: data && typeof data === 'object' ? Object.keys(data) : null,
+    });
   }
   return data;
 };


### PR DESCRIPTION
## Summary
- ensure the login flow persists the `access_token` returned by `/users/login`
- migrate the localStorage fallback to use the `access_token` key while cleaning up the legacy key

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f4c1278832786494ff5e07b6554