### PR TITLE
Fix coach avatar animation while typing

### DIFF
--- a/src/features/toolbox/components/CoachIA.jsx
+++ b/src/features/toolbox/components/CoachIA.jsx
@@ -554,19 +554,20 @@ const CoachIA = ({ onClose, onExpand, layout = 'dock' }) => {
 
   useEffect(() => {
     if (coachIsSpeaking) {
-      setActiveFrame(0);
       if (!speakingIntervalRef.current) {
+        setActiveFrame(0);
         speakingIntervalRef.current = setInterval(() => {
           setActiveFrame((prev) => (prev + 1) % coachFrames.length);
         }, 120);
       }
-    } else {
-      if (speakingIntervalRef.current) {
-        clearInterval(speakingIntervalRef.current);
-        speakingIntervalRef.current = null;
-      }
-      setActiveFrame(0);
+      return;
     }
+
+    if (speakingIntervalRef.current) {
+      clearInterval(speakingIntervalRef.current);
+      speakingIntervalRef.current = null;
+    }
+    setActiveFrame(0);
   }, [coachIsSpeaking]);
 
   useEffect(


### PR DESCRIPTION
## Summary
- prevent the coach avatar animation frame from resetting on every render while the assistant is speaking
- keep the frame cycling interval active only while the coach is responding and reset it cleanly afterwards

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d57e9323908327b3c5f52dd9e80e48