### PR TITLE
Adapt chat frontend to backend conversation history

### DIFF
--- a/src/features/chat/components/CapsuleChatPanel.jsx
+++ b/src/features/chat/components/CapsuleChatPanel.jsx
@@ -31,6 +31,8 @@ const CapsuleChatPanel = ({ domain, area, capsuleTitle }) => {
     return base;
   }, [sanitizedArea, sanitizedDomain]);
 
+  const historyParamsValue = useMemo(() => ({ capsule: capsuleTitle }), [capsuleTitle]);
+
   return (
     <Paper variant="outlined" sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Stack direction="row" spacing={1.5} alignItems="center">
@@ -58,6 +60,8 @@ const CapsuleChatPanel = ({ domain, area, capsuleTitle }) => {
           showActiveUsers
           variant="embedded"
           metadata={{ capsule: capsuleTitle }}
+          historyRoomId={sanitizedDomain}
+          historyParams={historyParamsValue}
         />
       </ChatProvider>
       <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/src/features/chat/components/ChatMessageList.jsx
+++ b/src/features/chat/components/ChatMessageList.jsx
@@ -2,9 +2,10 @@ import React, { useEffect, useRef } from 'react';
 import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import ChatMessageItem from './ChatMessageItem';
 
-const ChatMessageList = ({ messages, status, currentUsername }) => {
+const ChatMessageList = ({ messages, status, currentUsername, isLoadingHistory = false, hasHistory = false }) => {
   const bottomRef = useRef(null);
-  const isLoading = status === 'connecting';
+  const isLoadingConnection = status === 'connecting';
+  const isLoading = isLoadingConnection || isLoadingHistory;
 
   useEffect(() => {
     if (!bottomRef.current) return;
@@ -12,6 +13,7 @@ const ChatMessageList = ({ messages, status, currentUsername }) => {
   }, [messages]);
 
   const hasMessages = Array.isArray(messages) && messages.length > 0;
+  const isReady = hasHistory || ['connected', 'closed', 'error'].includes(status);
 
   return (
     <Box sx={{ flex: 1, overflowY: 'auto', pr: 1 }}>
@@ -32,7 +34,7 @@ const ChatMessageList = ({ messages, status, currentUsername }) => {
           <Box ref={bottomRef} />
         </Stack>
       ) : (
-        !isLoading && (
+        !isLoading && isReady && (
           <Stack spacing={1} sx={{ py: 4, alignItems: 'center', color: 'text.secondary' }}>
             <Typography variant="body2">Aucun message pour le moment.</Typography>
             <Typography variant="body2">Soyez la première personne à lancer la discussion !</Typography>

--- a/src/features/chat/components/ChatRoomHeader.jsx
+++ b/src/features/chat/components/ChatRoomHeader.jsx
@@ -16,12 +16,15 @@ const STATUS_CONFIG = {
   error: { label: 'Erreur', color: 'error' },
   closed: { label: 'Déconnecté', color: 'default' },
   idle: { label: 'Inactif', color: 'default' },
+  loading: { label: 'Chargement…', color: 'info' },
+  'loading-history': { label: 'Chargement…', color: 'info' },
 };
 
 const ChatRoomHeader = ({
   title,
   description,
   status,
+  isLoadingHistory = false,
   areaFilter,
   onAreaFilterChange,
   areaOptions = [],
@@ -30,7 +33,8 @@ const ChatRoomHeader = ({
   actions,
   activeCount,
 }) => {
-  const statusConfig = STATUS_CONFIG[status] || STATUS_CONFIG.idle;
+  const statusKey = isLoadingHistory ? 'loading' : status;
+  const statusConfig = STATUS_CONFIG[statusKey] || STATUS_CONFIG.idle;
   const hasAreaFilter = showAreaFilter && areaOptions.length > 0;
 
   return (

--- a/src/features/chat/context/ChatProvider.jsx
+++ b/src/features/chat/context/ChatProvider.jsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { buildChatSocketUrl } from '../../../config/api';
+import { fetchChatHistory } from '../api/chatApi';
 
 const ChatContext = createContext(null);
 
@@ -20,6 +21,7 @@ const createInitialRoomState = () => ({
   refCount: 0,
   lastEventAt: null,
   hasHistory: false,
+  isFetchingHistory: false,
 });
 
 const toError = (value) => {
@@ -33,27 +35,145 @@ const toError = (value) => {
 const eventTypeMatches = (type, expected) => {
   if (!type) return false;
   if (type === expected) return true;
-  return type === `chat.${expected}`;
+  if (type === `chat.${expected}`) return true;
+  if (type.endsWith(`.${expected}`)) return true;
+  if (type.endsWith(`:${expected}`)) return true;
+  return false;
+};
+
+const eventMatchesAny = (type, ...expected) => expected.some((item) => eventTypeMatches(type, item));
+
+const collectMessagesFromPayload = (payload) => {
+  if (!payload || typeof payload !== 'object') return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload.messages)) return payload.messages;
+  if (Array.isArray(payload.items)) return payload.items;
+  if (Array.isArray(payload.data?.messages)) return payload.data.messages;
+  if (Array.isArray(payload.data?.items)) return payload.data.items;
+  if (Array.isArray(payload.conversation?.messages)) return payload.conversation.messages;
+  if (Array.isArray(payload.history)) return payload.history;
+  if (Array.isArray(payload.entries)) return payload.entries;
+  return [];
+};
+
+const collectUsersFromPayload = (payload) => {
+  if (!payload || typeof payload !== 'object') return [];
+  if (Array.isArray(payload.users)) return payload.users;
+  if (Array.isArray(payload.activeUsers)) return payload.activeUsers;
+  if (Array.isArray(payload.active_users)) return payload.active_users;
+  if (Array.isArray(payload.data?.users)) return payload.data.users;
+  if (Array.isArray(payload.data?.active_users)) return payload.data.active_users;
+  if (Array.isArray(payload.state?.users)) return payload.state.users;
+  return [];
 };
 
 const normalizeMessage = (raw) => {
   if (!raw) return null;
-  const source = raw.payload || raw.message || raw;
+  const source = raw.payload || raw.message || raw.data?.message || raw.data || raw;
   if (!source) return null;
 
-  const username = source.username || source.user?.username || source.author || 'Utilisateur';
+  const role =
+    source.role ||
+    source.author_role ||
+    source.sender_role ||
+    source.sender?.role ||
+    raw.role ||
+    null;
+
+  let username =
+    source.username ||
+    source.user?.username ||
+    source.author ||
+    source.sender?.username ||
+    source.sender?.name ||
+    source.sender_name ||
+    source.display_name ||
+    raw.username ||
+    null;
+
+  if (!username) {
+    if (role === 'assistant' || source.type === 'assistant') {
+      username = source.assistant_name || source.bot_name || 'Nanshe';
+    } else if (role === 'user') {
+      username = source.user?.name || source.user_name || 'Utilisateur';
+    } else if (role === 'system' || source.system || source.type === 'system') {
+      username = 'Système';
+    }
+  }
+
+  if (!username) {
+    username = 'Utilisateur';
+  }
+
   const id =
     source.id ||
     source.message_id ||
     source.uuid ||
     source._id ||
-    `${username}-${source.created_at || source.timestamp || Date.now()}`;
+    raw.id ||
+    raw.message_id ||
+    raw.uuid ||
+    `${username}-${
+      source.created_at ||
+      source.createdAt ||
+      source.created ||
+      source.timestamp ||
+      source.sent_at ||
+      raw.timestamp ||
+      Date.now()
+    }`;
+
   const createdAt =
-    source.created_at || source.createdAt || source.timestamp || source.sent_at || new Date().toISOString();
-  const content = source.content || source.message || source.text || '';
-  const domain = source.domain || source.room?.domain || source.metadata?.domain || null;
-  const area = source.area || source.topic_area || source.metadata?.area || null;
-  const system = Boolean(source.system || source.type === 'system');
+    source.created_at ||
+    source.createdAt ||
+    source.created ||
+    source.timestamp ||
+    source.sent_at ||
+    raw.timestamp ||
+    new Date().toISOString();
+
+  const contentCandidates = [];
+  if (typeof source.content === 'string') contentCandidates.push(source.content);
+  if (typeof source.message === 'string') contentCandidates.push(source.message);
+  if (typeof source.text === 'string') contentCandidates.push(source.text);
+  if (typeof source.body === 'string') contentCandidates.push(source.body);
+  if (typeof source.value === 'string') contentCandidates.push(source.value);
+  if (typeof source.prompt === 'string') contentCandidates.push(source.prompt);
+  if (typeof source.output === 'string') contentCandidates.push(source.output);
+  if (typeof source.summary === 'string') contentCandidates.push(source.summary);
+  if (typeof raw.content === 'string') contentCandidates.push(raw.content);
+  if (typeof raw.text === 'string') contentCandidates.push(raw.text);
+  if (typeof raw.message === 'string') contentCandidates.push(raw.message);
+  if (typeof source.data?.content === 'string') contentCandidates.push(source.data.content);
+  if (typeof source.data?.text === 'string') contentCandidates.push(source.data.text);
+  if (Array.isArray(source.parts)) {
+    source.parts.forEach((part) => {
+      if (typeof part === 'string') {
+        contentCandidates.push(part);
+      } else if (part && typeof part === 'object') {
+        if (typeof part.content === 'string') contentCandidates.push(part.content);
+        if (typeof part.text === 'string') contentCandidates.push(part.text);
+        if (typeof part.value === 'string') contentCandidates.push(part.value);
+      }
+    });
+  }
+  const content = contentCandidates.find((entry) => typeof entry === 'string' && entry.trim().length > 0) || '';
+
+  const domain =
+    source.domain ||
+    source.room?.domain ||
+    source.metadata?.domain ||
+    source.context?.domain ||
+    raw.domain ||
+    null;
+  const area =
+    source.area ||
+    source.topic_area ||
+    source.metadata?.area ||
+    source.context?.area ||
+    raw.area ||
+    null;
+  const system = Boolean(source.system || source.type === 'system' || role === 'system');
 
   return {
     id,
@@ -63,21 +183,35 @@ const normalizeMessage = (raw) => {
     area,
     createdAt,
     system,
-    userId: source.user_id || source.userId || source.user?.id || null,
+    role: role || (system ? 'system' : undefined),
+    userId: source.user_id || source.userId || source.user?.id || source.sender?.id || raw.user_id || null,
+    conversationId:
+      source.conversation_id ||
+      source.conversationId ||
+      source.conversation?.id ||
+      raw.conversation_id ||
+      null,
   };
 };
 
 const normalizeUser = (raw) => {
   if (!raw) return null;
-  const username = raw.username || raw.name || raw.display_name || raw.user?.username;
+  const source = raw.user || raw;
+  const username =
+    source.username ||
+    source.name ||
+    source.display_name ||
+    source.handle ||
+    source.user?.username;
   if (!username) return null;
   return {
-    id: raw.id || raw.user_id || username,
+    id: source.id || source.user_id || raw.id || username,
     username,
-    avatar: raw.avatar || raw.avatar_url || raw.user?.avatar || null,
-    domain: raw.domain || raw.room?.domain || null,
-    area: raw.area || raw.topic_area || null,
-    status: raw.status || 'online',
+    avatar: source.avatar || source.avatar_url || source.image || source.user?.avatar || null,
+    domain: source.domain || source.room?.domain || raw.domain || null,
+    area: source.area || source.topic_area || raw.area || null,
+    status: source.status || raw.status || 'online',
+    role: source.role || raw.role || null,
   };
 };
 
@@ -103,6 +237,7 @@ const mergeMessages = (current = [], incoming = []) => {
 export const ChatProvider = ({ children }) => {
   const [rooms, setRooms] = useState({});
   const socketsRef = useRef(new Map());
+  const historyRequestsRef = useRef(new Map());
 
   const handleIncoming = useCallback((roomId, rawData) => {
     if (!rawData) return;
@@ -124,65 +259,211 @@ export const ChatProvider = ({ children }) => {
       const current = prev[roomId] ? { ...prev[roomId] } : createInitialRoomState();
       const next = { ...current, lastEventAt: Date.now() };
 
-      const payload = parsed.payload ?? parsed;
-      const type = parsed.type || parsed.event || payload?.type;
+      const payload = parsed.payload ?? parsed.data ?? parsed.body ?? parsed.message ?? parsed;
+      const type = parsed.type || parsed.event || payload?.type || payload?.event || payload?.kind;
 
-      if (Array.isArray(parsed) || Array.isArray(payload?.messages)) {
-        const history = (Array.isArray(parsed) ? parsed : payload.messages)
-          .map((item) => normalizeMessage(item))
-          .filter(Boolean);
-        next.messages = mergeMessages(current.messages, history);
+      const historyItems = [];
+      if (Array.isArray(parsed)) {
+        historyItems.push(...parsed);
+      }
+      const payloadMessages = collectMessagesFromPayload(payload);
+      if (payloadMessages.length > 0) {
+        historyItems.push(...payloadMessages);
+      }
+
+      if (historyItems.length > 0) {
+        const history = historyItems.map((item) => normalizeMessage(item)).filter(Boolean);
+        if (history.length > 0) {
+          next.messages = mergeMessages(current.messages, history);
+        }
         next.hasHistory = true;
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      if (eventTypeMatches(type, 'message') || (!type && payload && (payload.content || payload.message))) {
-        const message = normalizeMessage(payload);
+      if (
+        eventMatchesAny(
+          type,
+          'message',
+          'message.created',
+          'conversation.message',
+          'conversation.message.created',
+          'chat.message.created',
+          'chat.message'
+        ) ||
+        payload?.kind === 'message' ||
+        (!type && payload && (payload.content || payload.message || payload.text))
+      ) {
+        const messagePayload = payload?.message || payload?.data || payload?.entry || payload;
+        const message = normalizeMessage(messagePayload);
         if (!message) return prev;
         next.messages = mergeMessages(current.messages, [message]);
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      if (eventTypeMatches(type, 'history')) {
-        const history = (payload?.messages || payload || [])
+      if (
+        eventMatchesAny(type, 'history', 'history.loaded', 'conversation.history', 'conversation.history.loaded') ||
+        payload?.kind === 'history'
+      ) {
+        const history = collectMessagesFromPayload(payload)
           .map((item) => normalizeMessage(item))
           .filter(Boolean);
-        next.messages = mergeMessages(current.messages, history);
+        if (history.length > 0) {
+          next.messages = mergeMessages(current.messages, history);
+        }
         next.hasHistory = true;
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      if (eventTypeMatches(type, 'users')) {
-        const users = (payload?.users || payload || [])
+      const usersFromPayload = collectUsersFromPayload(payload);
+      if (eventMatchesAny(type, 'users', 'presence', 'active_users') || usersFromPayload.length > 0) {
+        const users = usersFromPayload
           .map((item) => normalizeUser(item))
           .filter(Boolean);
         next.activeUsers = users;
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      if (eventTypeMatches(type, 'error')) {
+      if (eventMatchesAny(type, 'metadata', 'room.metadata') && payload?.metadata) {
+        next.metadata = { ...current.metadata, ...payload.metadata };
+        next.isFetchingHistory = false;
+        return { ...prev, [roomId]: next };
+      }
+
+      if (eventMatchesAny(type, 'error', 'conversation.error')) {
         next.error = toError(payload?.error || payload);
         next.status = 'error';
+        next.isFetchingHistory = false;
         return { ...prev, [roomId]: next };
       }
 
-      if (eventTypeMatches(type, 'system')) {
+      if (eventMatchesAny(type, 'system', 'system.message')) {
         const message = normalizeMessage({ ...payload, system: true });
         if (!message) return prev;
         next.messages = mergeMessages(current.messages, [message]);
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      if (payload?.content || payload?.message) {
+      if (payload?.metadata && typeof payload.metadata === 'object') {
+        next.metadata = { ...current.metadata, ...payload.metadata };
+      }
+
+      if (payload?.content || payload?.message || payload?.text) {
         const message = normalizeMessage(payload);
         if (!message) return prev;
         next.messages = mergeMessages(current.messages, [message]);
+        next.isFetchingHistory = false;
+        if (next.status === 'loading-history') {
+          next.status = 'idle';
+        }
         return { ...prev, [roomId]: next };
       }
 
-      return prev;
+      next.isFetchingHistory = false;
+      if (next.status === 'loading-history') {
+        next.status = 'idle';
+      }
+      return { ...prev, [roomId]: next };
     });
   }, []);
+
+  const loadHistory = useCallback(
+    async (targetRoomId, { requestId, params, skipIfLoaded = true } = {}) => {
+      if (!targetRoomId) return null;
+      const effectiveRequestId = requestId || targetRoomId;
+      const paramsKey = params && typeof params === 'object' ? JSON.stringify(params) : '';
+      const cacheKey = `${targetRoomId}::${effectiveRequestId}::${paramsKey}`;
+      if (historyRequestsRef.current.has(cacheKey)) {
+        return historyRequestsRef.current.get(cacheKey);
+      }
+
+      let shouldAbort = false;
+
+      setRooms((prev) => {
+        const current = prev[targetRoomId] ? { ...prev[targetRoomId] } : createInitialRoomState();
+        if (skipIfLoaded && current.hasHistory) {
+          shouldAbort = true;
+          return prev;
+        }
+        return {
+          ...prev,
+          [targetRoomId]: {
+            ...current,
+            isFetchingHistory: true,
+            status: current.status === 'idle' ? 'loading-history' : current.status,
+            error: current.error,
+          },
+        };
+      });
+
+      if (shouldAbort) {
+        return null;
+      }
+
+      const requestPromise = (async () => {
+        try {
+          const response = await fetchChatHistory(effectiveRequestId, params || {});
+          const items = Array.isArray(response) ? response : [];
+          const messages = items.map((item) => normalizeMessage(item)).filter(Boolean);
+          setRooms((prev) => {
+            const current = prev[targetRoomId] ? { ...prev[targetRoomId] } : createInitialRoomState();
+            return {
+              ...prev,
+              [targetRoomId]: {
+                ...current,
+                messages: mergeMessages(current.messages, messages),
+                hasHistory: true,
+                isFetchingHistory: false,
+                status: current.status === 'loading-history' ? 'idle' : current.status,
+                lastEventAt: Date.now(),
+              },
+            };
+          });
+          return messages;
+        } catch (error) {
+          setRooms((prev) => {
+            const current = prev[targetRoomId] ? { ...prev[targetRoomId] } : createInitialRoomState();
+            return {
+              ...prev,
+              [targetRoomId]: {
+                ...current,
+                isFetchingHistory: false,
+                status: current.status === 'loading-history' ? 'error' : current.status,
+                error: toError(error),
+                lastEventAt: Date.now(),
+              },
+            };
+          });
+          throw error;
+        } finally {
+          historyRequestsRef.current.delete(cacheKey);
+        }
+      })();
+
+      historyRequestsRef.current.set(cacheKey, requestPromise);
+      return requestPromise;
+    },
+    []
+  );
 
   const closeSocket = useCallback((roomId, code = 1000, reason = 'client-leave') => {
     const socket = socketsRef.current.get(roomId);
@@ -336,8 +617,9 @@ export const ChatProvider = ({ children }) => {
       joinRoom,
       leaveRoom,
       sendMessage: sendMessageInternal,
+      loadHistory,
     }),
-    [joinRoom, leaveRoom, rooms, sendMessageInternal]
+    [joinRoom, leaveRoom, loadHistory, rooms, sendMessageInternal]
   );
 
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
@@ -351,10 +633,32 @@ export const useChatContext = () => {
   return context;
 };
 
-export const useChatRoom = (roomId, { metadata, autoJoin = true } = {}) => {
-  const { rooms, joinRoom, leaveRoom, sendMessage } = useChatContext();
+export const useChatRoom = (roomId, { metadata, autoJoin = true, history } = {}) => {
+  const { rooms, joinRoom, leaveRoom, sendMessage, loadHistory } = useChatContext();
   const metadataRef = useRef(metadata);
   metadataRef.current = metadata;
+
+  const historyConfig = useMemo(() => {
+    if (!history) {
+      return { autoLoad: true, requestId: null, params: null, skipIfLoaded: true };
+    }
+    return {
+      autoLoad: history.autoLoad !== false,
+      requestId: history.requestId || history.roomId || null,
+      params: history.params || null,
+      skipIfLoaded: history.skipIfLoaded !== false,
+      reloadToken: history.reloadToken || null,
+    };
+  }, [history]);
+
+  const historyOptionsRef = useRef(historyConfig);
+  historyOptionsRef.current = historyConfig;
+
+  const historyKey = useMemo(() => {
+    if (!historyConfig.autoLoad) return null;
+    const paramsKey = historyConfig.params ? JSON.stringify(historyConfig.params) : '';
+    return `${roomId || ''}::${historyConfig.requestId || ''}::${paramsKey}::${historyConfig.reloadToken || ''}`;
+  }, [historyConfig, roomId]);
 
   useEffect(() => {
     if (!autoJoin || !roomId) return undefined;
@@ -363,6 +667,16 @@ export const useChatRoom = (roomId, { metadata, autoJoin = true } = {}) => {
       leaveRoom(roomId);
     };
   }, [autoJoin, joinRoom, leaveRoom, roomId]);
+
+  useEffect(() => {
+    if (!roomId || !historyConfig.autoLoad) return;
+    const options = historyOptionsRef.current;
+    loadHistory(roomId, {
+      requestId: options.requestId || undefined,
+      params: options.params || undefined,
+      skipIfLoaded: options.skipIfLoaded,
+    });
+  }, [historyKey, historyConfig.autoLoad, loadHistory, roomId]);
 
   const roomState = rooms[roomId] || createInitialRoomState();
 
@@ -377,5 +691,10 @@ export const useChatRoom = (roomId, { metadata, autoJoin = true } = {}) => {
   return {
     ...roomState,
     sendMessage: send,
+    requestHistory: (options) =>
+      loadHistory(roomId, {
+        ...(options || {}),
+        requestId: options?.requestId || options?.roomId || historyConfig.requestId || roomId,
+      }),
   };
 };

--- a/src/features/chat/pages/DomainChatPage.jsx
+++ b/src/features/chat/pages/DomainChatPage.jsx
@@ -60,6 +60,7 @@ const DomainChatPage = () => {
       allowAreaSelection
       showActiveUsers
       variant="full"
+      historyRoomId={roomKey}
     />
   );
 };

--- a/src/features/chat/pages/GeneralChatPage.jsx
+++ b/src/features/chat/pages/GeneralChatPage.jsx
@@ -19,6 +19,7 @@ const GeneralChatPage = () => {
       allowAreaSelection={false}
       showActiveUsers
       variant="full"
+      historyRoomId="general"
     />
   );
 };


### PR DESCRIPTION
## Summary
- normalize chat payloads and add history loading support in the chat provider
- fetch initial history for chat rooms and surface loading states in the room view and message list
- wire capsule, general and domain chat views to request backend conversation history metadata

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af07e87483279ff0e314c6c8c654