### PR TITLE
Fix CoachIA initialization order to avoid runtime crash

### DIFF
--- a/src/features/toolbox/components/CoachIA.jsx
+++ b/src/features/toolbox/components/CoachIA.jsx
@@ -840,6 +840,8 @@ const CoachIA = ({ onClose, onExpand, layout = 'dock' }) => {
   );
   const agentTooltip = quickActions.find((action) => action.type === 'agent_mode')?.tooltip;
 
+  const queryClient = useQueryClient();
+
   useEffect(() => {
     writeStoredConversationId(conversationId);
   }, [conversationId]);
@@ -894,8 +896,6 @@ const CoachIA = ({ onClose, onExpand, layout = 'dock' }) => {
       cancelled = true;
     };
   }, [queryClient]);
-
-  const queryClient = useQueryClient();
   const {
     data: energy,
     isLoading: isEnergyLoading,


### PR DESCRIPTION
## Summary
- ensure the React Query client is initialized before any effects use it in CoachIA

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c4be27a88327895fc8e4101b5f95