### PR TITLE
Attach access token to WebSocket URLs

### DIFF
--- a/src/contexts/WebSocketProvider.jsx
+++ b/src/contexts/WebSocketProvider.jsx
@@ -1,6 +1,6 @@
 // src/contexts/WebSocketProvider.jsx
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { API_WS_URL } from '../config/api';
+import { buildApiWsUrl } from '../config/api';
 import { getStoredAccessToken } from '../utils/authTokens';
 
 // 👉 le contexte expose maintenant { lastMessage, connected, reconnect, disconnect }
@@ -34,7 +34,8 @@ export const WebSocketProvider = ({ children }) => {
     }
 
     try {
-      const socket = new window.WebSocket(API_WS_URL);
+      const socketUrl = buildApiWsUrl();
+      const socket = new window.WebSocket(socketUrl);
       socketRef.current = socket;
 
       socket.onopen = () => {


### PR DESCRIPTION
## Summary
- add reusable helpers for building API and chat WebSocket URLs that automatically attach the stored access token when present
- ensure the shared WebSocket provider opens connections with the token-aware URL builder

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c63f5a3c83279b407308a7113a89