### PR TITLE
feat: reinforce auth password UX

### DIFF
--- a/src/features/authentication/components/AuthDialog.module.css
+++ b/src/features/authentication/components/AuthDialog.module.css
@@ -23,3 +23,18 @@
 .linkRow{text-align:right}
 .linkInline{font-size:.9rem;color:#8b5cf6;text-decoration:none}
 .alertError{background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.3);color:#ef4444;border-radius:10px;padding:10px;margin-bottom:10px}
+.inputWrapper{position:relative;display:flex;align-items:center}
+.inputWrapper .input{width:100%;padding-right:44px}
+.inputToggle{position:absolute;right:12px;background:transparent;border:0;font-size:1.1rem;cursor:pointer;opacity:.7;transition:opacity .2s ease}
+.inputToggle:hover{opacity:1}
+.rememberRow{display:flex;align-items:center;gap:8px;font-size:.9rem;color:inherit;cursor:pointer;user-select:none}
+.rememberCheckbox{width:18px;height:18px;border-radius:4px}
+.passwordRules{margin-top:6px;background:rgba(139,92,246,.08);border:1px solid rgba(139,92,246,.18);border-radius:12px;padding:12px}
+.passwordRules p{margin:0 0 6px;font-weight:600;font-size:.9rem}
+.passwordRules ul{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;font-size:.85rem}
+.passwordRules li{list-style:'✦ ';color:rgba(17,17,27,.8)}
+@media (prefers-color-scheme: dark){
+  .passwordRules{background:rgba(139,92,246,.12);border-color:rgba(139,92,246,.3)}
+  .passwordRules li{color:rgba(240,230,255,.85)}
+}
+.passwordRules li[data-valid=true]{color:#10b981;font-weight:600;list-style:'✔ ';}

--- a/src/features/authentication/pages/LoginPage.jsx
+++ b/src/features/authentication/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 // Fichier: src/features/authentication/pages/LoginPage.jsx (FINAL)
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../../hooks/useAuth';
 import {
   TextField,
@@ -13,9 +13,11 @@ import {
   InputAdornment,
   IconButton,
   Stack,
-  Divider
+  Divider,
+  Checkbox,
+  FormControlLabel
 } from '@mui/material';
-import { styled, alpha, keyframes, useTheme } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import PersonOutlineRoundedIcon from '@mui/icons-material/PersonOutlineRounded';
 import LockRoundedIcon from '@mui/icons-material/LockRounded';
 import Visibility from '@mui/icons-material/Visibility';
@@ -28,10 +30,10 @@ const LoginPage = () => {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
   const { login, isLoading } = useAuth();
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
-  const navigate = useNavigate();
 
   const background = isDark
     ? `radial-gradient(1200px 600px at 10% 10%, ${alpha(theme.palette.primary.main,0.13)}, transparent 60%),
@@ -75,7 +77,7 @@ const LoginPage = () => {
     e.preventDefault();
     setError('');
     try {
-      await login({ username, password });
+      await login({ username, password, rememberMe });
     } catch (err) {
       setError(err.response?.data?.detail || "Nom d'utilisateur ou mot de passe incorrect.");
     }
@@ -177,6 +179,18 @@ const LoginPage = () => {
             >
               {isLoading ? <CircularProgress size={22} /> : 'Se connecter'}
             </Button>
+
+            <FormControlLabel
+              control={(
+                <Checkbox
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                  color="secondary"
+                />
+              )}
+              label="Rester connecté"
+              sx={{ mt: 1, color: theme.palette.text.secondary }}
+            />
 
             <Stack direction="row" alignItems="center" justifyContent="center" sx={{ mt: 2 }}>
               <Typography variant="body2" sx={{ color: theme.palette.text.secondary }}>

--- a/src/utils/passwordValidation.js
+++ b/src/utils/passwordValidation.js
@@ -1,0 +1,38 @@
+export const PASSWORD_RULES = [
+  {
+    key: 'length',
+    label: 'Au moins 8 caractères',
+    test: (value = '') => value.length >= 8,
+  },
+  {
+    key: 'lowercase',
+    label: 'Au moins une lettre minuscule',
+    test: (value = '') => /[a-z]/.test(value),
+  },
+  {
+    key: 'uppercase',
+    label: 'Au moins une lettre majuscule',
+    test: (value = '') => /[A-Z]/.test(value),
+  },
+  {
+    key: 'number',
+    label: 'Au moins un chiffre',
+    test: (value = '') => /\d/.test(value),
+  },
+  {
+    key: 'special',
+    label: 'Au moins un caractère spécial',
+    test: (value = '') => /[^A-Za-z0-9]/.test(value),
+  },
+];
+
+export const getPasswordChecks = (value = '') => {
+  const input = typeof value === 'string' ? value : '';
+  return PASSWORD_RULES.reduce((acc, rule) => {
+    acc[rule.key] = rule.test(input);
+    return acc;
+  }, {});
+};
+
+export const isPasswordCompliant = (value = '') =>
+  Object.values(getPasswordChecks(value)).every(Boolean);


### PR DESCRIPTION
## Summary
- add password visibility toggles, rule checklist, and validation to signup flows
- introduce reusable password validation helpers for consistent rules
- surface "remember me" control and respect it when persisting access tokens

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6590b389c8327b1f7ba50350f514b