### PR TITLE
Add Vercel rewrite for client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel rewrite so that every request serves `index.html`
- ensure client-side routes continue to work after a full page reload

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d681f11610832783aab19362b92387