### PR TITLE
feat: include timezone headers in API requests

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import { API_V2_URL } from '../config/api';
 import { getStoredAccessToken } from '../utils/authTokens';
+import { getBrowserTimeZone, getTimezoneOffsetMinutes } from '../utils/timezone';
 
 // Client axios unique pour l'API v2
 const apiClient = axios.create({
@@ -12,9 +13,26 @@ const apiClient = axios.create({
 // Interceptor: ajoute Authorization si un fallback token (localStorage) existe
 apiClient.interceptors.request.use((config) => {
   const token = getStoredAccessToken();
+  const timezone = getBrowserTimeZone();
+  const timezoneOffset = getTimezoneOffsetMinutes();
+
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  if (timezone) {
+    config.headers = config.headers || {};
+    if (!config.headers['X-Timezone']) {
+      config.headers['X-Timezone'] = timezone;
+    }
+  }
+
+  if (typeof timezoneOffset === 'number') {
+    config.headers = config.headers || {};
+    if (!config.headers['X-Timezone-Offset']) {
+      config.headers['X-Timezone-Offset'] = timezoneOffset;
+    }
   }
   return config;
 });

--- a/src/utils/timezone.js
+++ b/src/utils/timezone.js
@@ -1,0 +1,30 @@
+export const getBrowserTimeZone = () => {
+  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+    return null;
+  }
+
+  try {
+    const { timeZone } = new Intl.DateTimeFormat().resolvedOptions();
+    return typeof timeZone === 'string' && timeZone.length > 0 ? timeZone : null;
+  } catch {
+    return null;
+  }
+};
+
+export const getTimezoneOffsetMinutes = () => {
+  if (typeof Date === 'undefined') {
+    return null;
+  }
+
+  try {
+    const offset = new Date().getTimezoneOffset();
+    return Number.isFinite(offset) ? offset : null;
+  } catch {
+    return null;
+  }
+};
+
+export default {
+  getBrowserTimeZone,
+  getTimezoneOffsetMinutes,
+};


### PR DESCRIPTION
## Summary
- add a timezone utility to safely read the browser locale and offset
- attach X-Timezone and X-Timezone-Offset headers to API v2 requests so the backend can produce aware datetimes

## Testing
- npm run lint *(fails: existing violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7027f4c1c8327bf45476d54f71003